### PR TITLE
minor optimization in inplace_alter_table, where instead of seeking t…

### DIFF
--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -354,4 +354,3 @@ class ha_tidesdb : public handler
                                     bool commit) override;
     bool check_if_incompatible_data(HA_CREATE_INFO *create_info, uint table_changes) override;
 };
-


### PR DESCRIPTION
…o first and skipping N rows after each batch commit, we now save the last data key and tidesdb_iter_seek directly to it