### PR TITLE
TideSQL 3 PATCH (v3.3.2)

### DIFF
--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -264,10 +264,10 @@ class ha_tidesdb : public handler
     /* Evaluate pushed index condition on a secondary-index entry before
        the expensive PK point-lookup.  Decodes the index key columns into
        buf and calls handler_index_cond_check().
-       Returns CHECK_POS  -- condition satisfied, proceed with PK lookup
-               CHECK_NEG  -- condition not satisfied, skip this entry
-               CHECK_OUT_OF_RANGE  -- past end of scan range
-               CHECK_ABORTED_BY_USER -- query killed */
+       Returns CHECK_POS                -- condition satisfied, proceed with PK lookup
+               CHECK_NEG                -- condition not satisfied, skip this entry
+               CHECK_OUT_OF_RANGE       -- past end of scan range
+               CHECK_ABORTED_BY_USER    -- query killed */
     check_result_t icp_check_secondary(const uint8_t *ik, size_t iks, uint idx, uchar *buf);
 
     /* Reverse a single integer sort-key part back to native little-endian
@@ -390,8 +390,8 @@ class ha_tidesdb : public handler
     IO_AND_CPU_COST scan_time() override;
 
    public:
-    /* Locking -- TidesDB handles all concurrency via MVCC internally.
-       lock_count()=0 bypasses MariaDB's THR_LOCK (same pattern as InnoDB). */
+    /* Locking -- TidesDB handles concurrency via MVCC internally.
+       lock_count()=0 bypasses MariaDB's THR_LOCK. */
     uint lock_count(void) const override
     {
         return 0;


### PR DESCRIPTION
correct heap corruption in serialize_row and improve auto_inc recovery
 
* added 2 bytes per field to serialize_row buffer estimate to account for
  length-prefix overhead from field_string::pack() on char columns, which
  prepends a 1-2 byte length not included in reclength, causing silent
  heap corruption under concurrent oltp_write_only workloads
* replaced raw memcpy in recover_counters() with proper deserialize_row()
  so auto_increment seeding works correctly even when variable-length
  fields precede the auto_increment column in the table definition
* bumped plugin version a patch to 3.3.2
 
verified sysbench oltp_write_only 8-16 threads / 3x10m rows / 300s clean, asan enabled