### PR TITLE
TideSQL 3 (v3.3.4)

### DIFF
--- a/README
+++ b/README
@@ -185,6 +185,7 @@ FEATURES
 Core:
 - MVCC transactions with per-table isolation (autocommit uses READ_COMMITTED;
   multi-statement transactions use the table's configured level)
+- SQL savepoints (SAVEPOINT / ROLLBACK TO / RELEASE SAVEPOINT)
 - Lock-free concurrency (no THR_LOCK, TidesDB handles isolation internally)
 - LSM-tree storage with optional B+tree SSTable format
 - Compression (NONE, LZ4, LZ4_FAST, ZSTD, Snappy)
@@ -322,6 +323,8 @@ Available tests:
   tidesdb_stress          Concurrent transactions, conflicts, truncate cycles
   tidesdb_sql             Comprehensive SQL: 40 cases (aggregates, JOINs,
                           subqueries, UNION, transactions, NULL handling, etc.)
+  tidesdb_json            JSON querying + generated-column JSON path indexing
+  tidesdb_savepoint       SQL SAVEPOINT / ROLLBACK TO / RELEASE SAVEPOINT
   tidesdb_write_pressure  oltp_write_only OOM reproduction (multi-connection)
 
 Run with verbose output:

--- a/mysql-test/suite/tidesdb/r/tidesdb_json.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_json.result
@@ -1,0 +1,50 @@
+#
+# ============================================
+# TEST: JSON querying + generated column indexing
+# ============================================
+#
+CREATE TABLE t_json (
+id   INT NOT NULL PRIMARY KEY,
+data LONGTEXT,
+name VARCHAR(50) AS (JSON_VALUE(data, '$.name')) PERSISTENT,
+age  INT AS (JSON_VALUE(data, '$.age')) PERSISTENT,
+KEY idx_name (name),
+KEY idx_age (age)
+) ENGINE=TIDESDB;
+INSERT INTO t_json (id, data) VALUES
+(1, '{"name":"Alice","age":30,"tags":["admin","dev"]}'),
+(2, '{"name":"Bob","age":25,"tags":["dev"]}'),
+(3, '{"name":"Carol","age":40,"tags":["finance"]}');
+# Basic JSON extraction
+SELECT id, JSON_VALUE(data, '$.name') AS jname, JSON_VALUE(data, '$.age') AS jage
+FROM t_json ORDER BY id;
+id	jname	jage
+1	Alice	30
+2	Bob	25
+3	Carol	40
+# Generated columns reflect JSON paths
+SELECT id, name, age FROM t_json ORDER BY id;
+id	name	age
+1	Alice	30
+2	Bob	25
+3	Carol	40
+# Filter using generated columns (indexable JSON paths)
+SELECT id, name, age FROM t_json WHERE name='Alice' ORDER BY id;
+id	name	age
+1	Alice	30
+SELECT id, name, age FROM t_json WHERE age >= 30 ORDER BY id;
+id	name	age
+1	Alice	30
+3	Carol	40
+# Filter using JSON function (non-indexed expression)
+SELECT id FROM t_json WHERE JSON_CONTAINS(data, '"admin"', '$.tags') ORDER BY id;
+id
+1
+# Update JSON and verify generated columns update
+UPDATE t_json SET data = JSON_SET(data, '$.age', 31) WHERE id = 1;
+SELECT id, name, age FROM t_json WHERE id = 1;
+id	name	age
+1	Alice	31
+DROP TABLE t_json;
+#
+# Done.

--- a/mysql-test/suite/tidesdb/r/tidesdb_savepoint.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_savepoint.result
@@ -1,0 +1,25 @@
+#
+# ============================================
+# TEST: SQL SAVEPOINT support
+# ============================================
+#
+CREATE TABLE t_sp (
+id INT PRIMARY KEY,
+v  INT
+) ENGINE=TIDESDB;
+# SAVEPOINT should work inside an explicit transaction
+START TRANSACTION;
+INSERT INTO t_sp VALUES (1, 10);
+SAVEPOINT a;
+INSERT INTO t_sp VALUES (2, 20);
+ROLLBACK TO SAVEPOINT a;
+INSERT INTO t_sp VALUES (3, 30);
+RELEASE SAVEPOINT a;
+COMMIT;
+SELECT * FROM t_sp ORDER BY id;
+id	v
+1	10
+3	30
+DROP TABLE t_sp;
+#
+# Done.

--- a/mysql-test/suite/tidesdb/t/tidesdb_json.opt
+++ b/mysql-test/suite/tidesdb/t/tidesdb_json.opt
@@ -1,0 +1,3 @@
+--plugin-maturity=unknown
+--plugin-load-add=ha_tidesdb
+--loose-tidesdb-json-test=1

--- a/mysql-test/suite/tidesdb/t/tidesdb_json.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_json.test
@@ -1,0 +1,44 @@
+--source include/not_embedded.inc
+
+--echo #
+--echo # ============================================
+--echo # TEST: JSON querying + generated column indexing
+--echo # ============================================
+--echo #
+
+CREATE TABLE t_json (
+  id   INT NOT NULL PRIMARY KEY,
+  data LONGTEXT,
+  name VARCHAR(50) AS (JSON_VALUE(data, '$.name')) PERSISTENT,
+  age  INT AS (JSON_VALUE(data, '$.age')) PERSISTENT,
+  KEY idx_name (name),
+  KEY idx_age (age)
+) ENGINE=TIDESDB;
+
+INSERT INTO t_json (id, data) VALUES
+  (1, '{"name":"Alice","age":30,"tags":["admin","dev"]}'),
+  (2, '{"name":"Bob","age":25,"tags":["dev"]}'),
+  (3, '{"name":"Carol","age":40,"tags":["finance"]}');
+
+--echo # Basic JSON extraction
+SELECT id, JSON_VALUE(data, '$.name') AS jname, JSON_VALUE(data, '$.age') AS jage
+FROM t_json ORDER BY id;
+
+--echo # Generated columns reflect JSON paths
+SELECT id, name, age FROM t_json ORDER BY id;
+
+--echo # Filter using generated columns (indexable JSON paths)
+SELECT id, name, age FROM t_json WHERE name='Alice' ORDER BY id;
+SELECT id, name, age FROM t_json WHERE age >= 30 ORDER BY id;
+
+--echo # Filter using JSON function (non-indexed expression)
+SELECT id FROM t_json WHERE JSON_CONTAINS(data, '"admin"', '$.tags') ORDER BY id;
+
+--echo # Update JSON and verify generated columns update
+UPDATE t_json SET data = JSON_SET(data, '$.age', 31) WHERE id = 1;
+SELECT id, name, age FROM t_json WHERE id = 1;
+
+DROP TABLE t_json;
+
+--echo #
+--echo # Done.

--- a/mysql-test/suite/tidesdb/t/tidesdb_savepoint.opt
+++ b/mysql-test/suite/tidesdb/t/tidesdb_savepoint.opt
@@ -1,0 +1,3 @@
+--plugin-maturity=unknown
+--plugin-load-add=ha_tidesdb
+--loose-tidesdb-savepoint-test=1

--- a/mysql-test/suite/tidesdb/t/tidesdb_savepoint.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_savepoint.test
@@ -1,0 +1,29 @@
+--source include/not_embedded.inc
+
+--echo #
+--echo # ============================================
+--echo # TEST: SQL SAVEPOINT support
+--echo # ============================================
+--echo #
+
+CREATE TABLE t_sp (
+  id INT PRIMARY KEY,
+  v  INT
+) ENGINE=TIDESDB;
+
+--echo # SAVEPOINT should work inside an explicit transaction
+START TRANSACTION;
+INSERT INTO t_sp VALUES (1, 10);
+SAVEPOINT a;
+INSERT INTO t_sp VALUES (2, 20);
+ROLLBACK TO SAVEPOINT a;
+INSERT INTO t_sp VALUES (3, 30);
+RELEASE SAVEPOINT a;
+COMMIT;
+
+SELECT * FROM t_sp ORDER BY id;
+
+DROP TABLE t_sp;
+
+--echo #
+--echo # Done.


### PR DESCRIPTION
* SQL SAVEPOINT support -- wired handlerton savepoint_set, savepoint_rollback,
    savepoint_release, and savepoint_rollback_can_release_mdl callbacks to
    TidesDB library savepoints.  SAVEPOINT / ROLLBACK TO SAVEPOINT / RELEASE
    SAVEPOINT now work inside explicit transactions.  Rollback re-creates the
    savepoint so that a subsequent RELEASE succeeds (matches SQL semantics).
* New MTR test -- tidesdb_savepoint (SAVEPOINT / ROLLBACK TO / RELEASE)
* New MTR test -- tidesdb_json (JSON querying + generated-column JSON path
    indexing)