### PR TITLE
add rebuild-plugin flag to install.sh for fast dev iteration, fix doc…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,137 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - 'tidesdb/**'
+      - 'mysql-test/**'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - 'tidesdb/**'
+      - 'mysql-test/**'
+      - '.github/workflows/docker.yml'
+
+env:
+  IMAGE_NAME: tidesql-ci
+
+jobs:
+  docker-build-and-run:
+    name: "Build & verify Docker image"
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve TidesDB version
+        id: versions
+        run: |
+          VERSION=$(curl -fsSL https://api.github.com/repos/tidesdb/tidesdb/releases/latest \
+            | grep '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Failed to fetch latest TidesDB version" >&2
+            exit 1
+          fi
+          echo "tidesdb=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/ubuntu/Dockerfile
+          push: false
+          load: true
+          tags: "${{ env.IMAGE_NAME }}:ci"
+          build-args: |
+            MARIADB_VERSION=11.8
+            TIDESDB_VERSION=${{ steps.versions.outputs.tidesdb }}
+            DISABLED_ENGINES=MROONGA,ROCKSDB,CONNECT,SPIDER,OQGRAPH,COLUMNSTORE
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start container
+        run: |
+          docker run -d \
+            --name tidesql-ci \
+            --tmpfs /tmp:exec \
+            "${{ env.IMAGE_NAME }}:ci"
+
+          echo "Waiting for MariaDB to start..."
+          for i in $(seq 1 60); do
+            if docker exec tidesql-ci mariadb -u root -e "SELECT 1" &>/dev/null; then
+              echo "MariaDB ready (${i}s)"
+              break
+            fi
+            if [ "$i" = "60" ]; then
+              echo "MariaDB failed to start within 60s"
+              docker logs tidesql-ci
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Verify TidesDB plugin is loaded
+        run: |
+          docker exec tidesql-ci mariadb -u root -e "
+            SELECT PLUGIN_NAME, PLUGIN_STATUS, PLUGIN_TYPE
+            FROM INFORMATION_SCHEMA.PLUGINS
+            WHERE PLUGIN_NAME = 'TidesDB';
+          "
+          docker exec tidesql-ci mariadb -u root -BN -e "
+            SELECT PLUGIN_STATUS
+            FROM INFORMATION_SCHEMA.PLUGINS
+            WHERE PLUGIN_NAME = 'TidesDB';
+          " | grep -q ACTIVE
+
+      - name: Smoke test
+        run: |
+          docker exec tidesql-ci mariadb -u root -e "
+            CREATE DATABASE IF NOT EXISTS ci_test;
+            USE ci_test;
+
+            CREATE TABLE t (
+              id   INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+              name VARCHAR(100)
+            ) ENGINE=TidesDB;
+
+            INSERT INTO t (name) VALUES ('alice'), ('bob'), ('charlie');
+            SELECT * FROM t ORDER BY id;
+
+            START TRANSACTION;
+            INSERT INTO t (name) VALUES ('should_not_exist');
+            ROLLBACK;
+
+            SELECT COUNT(*) AS expect_3 FROM t;
+
+            DROP TABLE t;
+            DROP DATABASE ci_test;
+          "
+
+      - name: SHOW ENGINE TIDESDB STATUS
+        run: |
+          docker exec tidesql-ci mariadb -u root -e "SHOW ENGINE TIDESDB STATUS\G"
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== Container logs ==="
+          docker logs tidesql-ci 2>&1 | tail -200
+
+          echo ""
+          echo "=== MariaDB error log ==="
+          docker exec tidesql-ci cat /usr/local/mariadb/log/error.log 2>/dev/null \
+            | tail -200 || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f tidesql-ci 2>/dev/null || true

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,51 +11,30 @@ storage engine) in a container.
     from GitHub
 
 
-## Tree
-
-```
-docker/
-├── conf/
-│   └── my.cnf
-├── ubuntu/
-│   ├── utils/
-│   │   └── cmake_exclude_engines.sh
-│   ├── Dockerfile
-│   └── entrypoint.sh
-├── README.md
-├── cleanup.sh
-├── rebuild.sh
-└── setup.sh
-```
-
-This tree will start to make sense when we add more operating systems (RedHat family, Arch)
-and some optional configuration files.
-
-
 ## Building Images
 
 To make building less error-prone, the following scripts are available:
-- `docker/cleanpup.sh` removes the existing image, any container
+- `docker/cleanup.sh` removes the existing image, any container
   created from it, and associated volumes.
-- `docker/build.sh` builds the image. This includes compiling MariaDB and
+- `docker/setup.sh` builds the image. This includes compiling MariaDB and
   TidesDB so, depending on your hardware, can take 20-40 minutes. It also
   creates a new container so that the image can be tested immediately.
 - `docker/rebuild.sh` calls both, passing all necessary environment
-  variable.
+  variables.
 
 These scripts can be called from any path.
 
 Environment variables accepted by the scripts:
 
-- `IMAGE_NAME`: Name of the newly built image, default: tidesql
-- `TAG`: Image tag, default: 11.8-ubuntu
-- `CONTAINER_NAME`: Name of the container to be created, default: tidesql
-- `MARIADB_VERSION`: MariaDB version to build, default: 11.8
-- `TIDESDB_VERSION`: TidesDB release tag to build, default: latest from GitHub
+- `IMAGE_NAME` Name of the newly built image, default: tidesql
+- `TAG` Image tag, default: latest
+- `CONTAINER_NAME` Name of the container to be created, default: tidesql
+- `MARIADB_VERSION` MariaDB version to build, default: 11.8
+- `TIDESDB_VERSION` TidesDB release tag to build, default: latest from GitHub
 - `EXCLUDE_ENGINES`  Comma-separated list of optional engines to exclude from the
   build.  Engine names are case-insensitive.  Use `ALL` to include all optional
   engines.
-- `INCLUDE_ENGINES`: Comma-separated list of optional engines to include.
+- `INCLUDE_ENGINES` Comma-separated list of optional engines to include.
   All other optional engines are excluded. Engine names are case-insensitive.
 
 `EXCLUDE_ENGINES` and `INCLUDE_ENGINES` cannot be set at the same time.
@@ -108,20 +87,20 @@ Some of them currently cannot be changed by using the scripts.
                     INCLUDE_ENGINES in rebuild.sh (see REBUILD SCRIPT above).
 ```
 
-`MARIADB_VERSION and TIDESDB_VERSION have no default in the Dockerfile and must
-always be supplied.  The scripts (rebuild.sh, setup.sh) default them to 11.8
-and the latest TidesDB release from GitHub respectively, so a bare
-"bash docker/rebuild.sh" works without any extra configuration.
+`MARIADB_VERSION` and `TIDESDB_VERSION` have no default in the Dockerfile and
+must always be supplied.  The scripts (`rebuild.sh`, `setup.sh`) default them
+to `11.8` and the latest TidesDB release from GitHub respectively, so a bare
+`bash docker/rebuild.sh` works without any extra configuration.
 
 Example - include the test suite:
 
 ```
   docker build \
       -f docker/ubuntu/Dockerfile \
-      --build-arg MARIADB_VERSION=11.8 \
-      --build-arg TIDESDB_VERSION=v8.8.0 \
+      --build-arg MARIADB_VERSION=12.2.2 \
+      --build-arg TIDESDB_VERSION=v8.9.3 \
       --build-arg WITH_TESTS=1 \
-      -t tidesql:11.8-ubuntu-tests \
+      -t tidesql:12.2.2-ubuntu-tests \
       .
 ```
 
@@ -138,7 +117,7 @@ restarts:
       -v tidesql-conf:/etc/mysql \
       -v tidesql-data:/usr/local/mariadb/data \
       -v tidesql-log:/usr/local/mariadb/log \
-      tidesql:11.8-ubuntu
+      tidesql:latest
 ```
 
 On the first start the entrypoint initialises the data directory
@@ -191,32 +170,3 @@ docker stop tidesql
 docker rm   tidesql
 docker volume rm tidesql-conf tidesql-data tidesql-log
 ```
-
-## MariaDB Tree
-
-MariaDB is installed in `/usr/local/mariadb`.
-
-We configured MariaDB to use a clean directory tree:
-
-```
-/usr/local/mariadb
-├── data
-│   └── default        (regular storage engines write here)
-|   └── tidesdb-data   (TidesDB data files and LOG)
-└── log
-    ├── binlog files
-    ├── error.log
-    ├── slow.log
-    ├── general.log
-    └── sqlerr.log     (SQL Error Log)
-```
-
-
-## To Do
-
-- Automatically create any number of containers (including zero)
-- Support more systems
-- Support all MariaDB Long-Term Support versions and some rolling versions
-- Anonymous volume containing SQL scripts to run on startup
-- Optionally create a test schema
-

--- a/docker/cleanup.sh
+++ b/docker/cleanup.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Configuration
 IMAGE_NAME=${IMAGE_NAME:-"tidesql"}
-TAG=${TAG:-"11.8-ubuntu"}
+TAG=${TAG:-"latest"}
 VOLUME_DATA="tidesql-data"
 VOLUME_CONF="tidesql-conf"
 VOLUME_LOG="tidesql-log"

--- a/docker/conf/my.cnf
+++ b/docker/conf/my.cnf
@@ -1,5 +1,6 @@
 [mysqld]
-port     = 3306
+port         = 3306
+bind-address = 0.0.0.0
 socket   = /tmp/mariadb.sock
 user     = mysql
 pid_file = mariadb.pid
@@ -90,10 +91,6 @@ tidesdb_compaction_threads = 2
 tidesdb_block_cache_size   = 268435456
 tidesdb_max_open_sstables  = 256
 tidesdb_log_level          = WARN
-
-# Query Cache
-query_cache_type  = 0
-query_cache_size  = 0
 
 [client]
 port                  = 3306

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -7,13 +7,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Configuration
 IMAGE_NAME=${IMAGE_NAME:-"tidesql"}
-TAG=${TAG:-"11.8-ubuntu"}
+TAG=${TAG:-"latest"}
 CONTAINER_NAME=${CONTAINER_NAME:-"tidesql"}
 VOLUME_DATA="tidesql-data"
 VOLUME_CONF="tidesql-conf"
 VOLUME_LOG="tidesql-log"
 
-# ── Storage engine selection ──────────────────────────────────────────────────
+# Storage engine selection 
 # Optional engines that can be excluded or selectively included.
 KNOWN_OPTIONAL_ENGINES="ARCHIVE BLACKHOLE CONNECT EXAMPLE FEDERATED FEDERATEDX MROONGA ROCKSDB S3 SPHINX SPIDER"
 # Engines that are always present in the build (cannot be excluded).
@@ -85,15 +85,15 @@ elif [ -n "${INCLUDE_ENGINES:-}" ]; then
     DISABLED_ENGINES="$_disabled"
 fi
 
-# ── Resolve MARIADB_VERSION and TIDESDB_VERSION ───────────────────────────────
+# Resolve MARIADB_VERSION and TIDESDB_VERSION 
 MARIADB_VERSION=${MARIADB_VERSION:-"11.8"}
 
 if [ -z "${TIDESDB_VERSION:-}" ]; then
     _tidesdb_latest=$(curl -fsSL "https://api.github.com/repos/tidesdb/tidesdb/releases/latest" 2>/dev/null \
         | grep '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
     if [ -z "$_tidesdb_latest" ]; then
-        echo "Warning: Could not fetch latest TidesDB version from GitHub; falling back to v8.8.0." >&2
-        _tidesdb_latest="v8.8.0"
+        echo "Warning: Could not fetch latest TidesDB version from GitHub; falling back to v8.9.0." >&2
+        _tidesdb_latest="v8.9.0"
     fi
     TIDESDB_VERSION="$_tidesdb_latest"
 fi
@@ -115,8 +115,8 @@ docker run -d \
     --name "$CONTAINER_NAME" \
     -p 3306:3306 \
     -v "$VOLUME_CONF":/etc/mysql \
-    -v "$VOLUME_DATA":/usr/local/mariadb/data \
-    -v "$VOLUME_LOG":/usr/local/mariadb/log \
+    -v "$VOLUME_DATA":"${MARIADB_PREFIX:-/usr/local/mariadb}"/data \
+    -v "$VOLUME_LOG":"${MARIADB_PREFIX:-/usr/local/mariadb}"/log \
     "${IMAGE_NAME}:${TAG}"
 r=$?
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -61,6 +61,7 @@ RUN git clone --depth 1 --branch "${MARIADB_VERSION}" \
     fi
 
 # ── 5. Configure, build, and install MariaDB ───────────────────────────────
+# Re-declare build ARGs so they are visible in this layer (Docker scoping rule).
 ARG WITH_TESTS=0
 ARG DISABLED_ENGINES=""
 COPY docker/ubuntu/utils/cmake_exclude_engines.sh /usr/local/bin/cmake_exclude_engines.sh
@@ -103,8 +104,8 @@ COPY docker/ubuntu/entrypoint.sh /usr/local/bin/tidesql-entrypoint.sh
 RUN chmod +x /usr/local/bin/tidesql-entrypoint.sh
 
 VOLUME /etc/mysql
-VOLUME /usr/local/mariadb/data
-VOLUME /usr/local/mariadb/log
+VOLUME ${MARIADB_PREFIX}/data
+VOLUME ${MARIADB_PREFIX}/log
 
 EXPOSE 3306
 

--- a/docker/ubuntu/entrypoint.sh
+++ b/docker/ubuntu/entrypoint.sh
@@ -4,12 +4,12 @@
 # If MARIADB_PREFIX/data/mysql does not exist the data directory is initialised
 # with mariadb-install-db.
 # The server is then started via mariadbd-safe.
-set -eo pipefail
+set -euo pipefail
 
 MARIADB_PREFIX="${MARIADB_PREFIX:-/usr/local/mariadb}"
 DATADIR="${MARIADB_PREFIX}/data/default"
 
-# ── Initialise data directory if it has not been set up yet ────────────────
+# Initialise data directory if it has not been set up yet 
 if [ ! -d "${DATADIR}/mysql" ]; then
     echo "[entrypoint] Initialising MariaDB data directory..."
 
@@ -41,7 +41,7 @@ if [ ! -d "${DATADIR}/mysql" ]; then
     echo "[entrypoint] Data directory initialised."
 fi
 
-# ── Start MariaDB ───────────────────────────────────────────────────────────
+# Start MariaDB ─
 # Ensure runtime directories exist with correct ownership (handles volume mounts).
 chown -R mysql:mysql /etc/mysql
 mkdir -p "${DATADIR}" "${MARIADB_PREFIX}/log"

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@
 #   --skip-tidesdb              Skip TidesDB library build (use if already installed)
 #   --skip-engines  ENGINES     Comma-separated list of storage engines to skip
 #   --list-engines              List storage engines that can be skipped and exit
+#   --rebuild-plugin             Rebuild only the TidesDB plugin (fast dev cycle)
 #   --pgo                       Enable Profile-Guided Optimization (3-phase build)
 #   --help                      Show this help message
 #
@@ -163,6 +164,7 @@ BUILD_DIR="${DEFAULT_BUILD_DIR}"
 JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
 SKIP_DEPS=false
 SKIP_TIDESDB=false
+REBUILD_PLUGIN=false
 PGO_ENABLED=false
 SKIP_ENGINES=""
 
@@ -240,6 +242,7 @@ while [[ $# -gt 0 ]]; do
         --jobs)             JOBS="$2";              shift 2 ;;
         --skip-deps)        SKIP_DEPS=true;         shift   ;;
         --skip-tidesdb)     SKIP_TIDESDB=true;      shift   ;;
+        --rebuild-plugin)   REBUILD_PLUGIN=true;    shift   ;;
         --skip-engines)     SKIP_ENGINES="$2";      shift 2 ;;
         --list-engines)     list_engines ;;
         --pgo)              PGO_ENABLED=true;       shift   ;;
@@ -825,6 +828,74 @@ print_summary() {
     draw_box "${GREEN}" "Installation Complete!" _summary_lines
 }
 
+# ── Rebuild only the TidesDB plugin (fast dev cycle) ────────────────
+rebuild_plugin() {
+    local mariadb_src="${BUILD_DIR}/mariadb-server"
+    local mariadb_build="${mariadb_src}/build"
+
+    if [[ ! -d "${mariadb_build}" ]]; then
+        die "MariaDB build directory not found at ${mariadb_build}.\n" \
+            "  Run a full install first before using --rebuild-plugin."
+    fi
+
+    # Re-copy plugin source & test suite into the existing source tree
+    info "Copying TidesDB plugin source into MariaDB source tree..."
+    cp -r "${SCRIPT_DIR}/tidesdb" "${mariadb_src}/storage/"
+    cp -r "${SCRIPT_DIR}/mysql-test/suite/tidesdb" "${mariadb_src}/mysql-test/suite/"
+
+    # Point cmake at the TidesDB library
+    export TIDESDB_ROOT="${TIDESDB_PREFIX}"
+
+    # Build just the plugin target
+    info "Building tidesdb plugin target (${JOBS} jobs)..."
+    cmake --build "${mariadb_build}" --target tidesdb --parallel "${JOBS}"
+
+    # Find the built .so/.dylib/.dll and copy it into the installed plugin dir
+    local plugin_ext="so"
+    [[ "$OS" == "macos" ]]   && plugin_ext="dylib"
+    [[ "$OS" == "windows" ]] && plugin_ext="dll"
+
+    local built_so
+    built_so="$(find "${mariadb_build}" -name "ha_tidesdb.${plugin_ext}" -print -quit 2>/dev/null)"
+    if [[ -z "$built_so" ]]; then
+        die "Could not find ha_tidesdb.${plugin_ext} in ${mariadb_build}"
+    fi
+
+    local plugin_dir="${MARIADB_PREFIX}/lib/plugin"
+    if [[ ! -d "$plugin_dir" ]]; then
+        plugin_dir="${MARIADB_PREFIX}/lib64/plugin"
+    fi
+    if [[ ! -d "$plugin_dir" ]]; then
+        die "Plugin directory not found at ${MARIADB_PREFIX}/lib/plugin or lib64/plugin"
+    fi
+
+    info "Installing ha_tidesdb.${plugin_ext} → ${plugin_dir}/"
+    run_privileged cp -f "${built_so}" "${plugin_dir}/"
+
+    ok "Plugin rebuilt and installed"
+
+    # Determine config file & socket for restart hint
+    local cnf_file="${MARIADB_PREFIX}/my.cnf"
+    [[ "$OS" == "windows" ]] && cnf_file="${MARIADB_PREFIX}/my.ini"
+
+    local _rebuild_lines=(
+        ""
+        "Plugin rebuilt : ${CYAN}${plugin_dir}/ha_tidesdb.${plugin_ext}${NC}"
+        ""
+        "Restart MariaDB to pick up the new plugin:"
+        "  ${MARIADB_PREFIX}/bin/mariadb-admin shutdown"
+        "  ${MARIADB_PREFIX}/bin/mariadbd-safe \\"
+        "    --defaults-file=${cnf_file} &"
+        ""
+        "Run TidesDB test suite:"
+        "  cd ${mariadb_build}/mysql-test"
+        "  perl mtr --suite=tidesdb --parallel=4"
+        ""
+    )
+
+    draw_box "${GREEN}" "Plugin Rebuild Complete" _rebuild_lines
+}
+
 # ── PGO Phase 1 -- Instrument build ─────────────────────────────────
 pgo_instrument() {
     info "PGO Phase 1/3: Building MariaDB with profiling instrumentation..."
@@ -1027,6 +1098,12 @@ pgo_optimize() {
 
 main() {
     mkdir -p "${BUILD_DIR}"
+
+    # Fast path: rebuild only the plugin and exit
+    if $REBUILD_PLUGIN; then
+        rebuild_plugin
+        return
+    fi
 
     install_deps
     build_tidesdb


### PR DESCRIPTION
…ker implementation bugs including missing bind-address in my.cnf, remove deprecated query cache directives, use dynamic mariadb prefix for volume paths in dockerfile, fix stale default versions and fallback tags in setup and cleanup scripts, correct readme typos and broken references, and add a docker.yml github actions workflow that builds the image and runs a smoke test to validate the container starts and loads the tidesdb plugin