### PR TITLE
TideSQL 4.1.0 MINOR

### DIFF
--- a/README
+++ b/README
@@ -235,6 +235,18 @@ Core:
 - ANALYZE TABLE with detailed CF statistics (levels, keys, sizes, cache hit rate)
 - Cached optimizer statistics (refreshed every 2 seconds from TidesDB)
 
+Cloud / Object Store:
+- S3-compatible object store backend (AWS S3, MinIO, GCS)
+- Four-tier hot/warm/cold/frozen storage hierarchy
+- Block-level range_get for point lookups on frozen SSTables (single HTTP request)
+- Parallel SSTable prefetch for iterators
+- Read-only replica mode with MANIFEST sync and WAL replay
+- Primary promotion via SET GLOBAL tidesdb_promote_primary = ON
+- Configurable WAL sync (per-commit for RPO=0, or bytes-threshold)
+- LRU local file cache with paired klog/vlog eviction
+- Upload retry with verification, download retry with backoff
+- Kubernetes deployment with automated failover (see k8s/ directory)
+
 
 CONFIGURATION
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
@@ -262,6 +274,20 @@ Read-only (set at startup):
   unified_memtable_sync_mode         NONE/INTERVAL/FULL for unified WAL (default: FULL)
   unified_memtable_sync_interval     Sync interval in µs for INTERVAL mode (default: 128000)
   row_lock_stripes          Legacy compat; lock table uses 256 hash partitions
+  object_store_backend      LOCAL or S3 (default: LOCAL)
+  s3_endpoint               S3 endpoint (e.g. s3.amazonaws.com)
+  s3_bucket                 S3 bucket name
+  s3_prefix                 S3 key prefix (e.g. production/db1/)
+  s3_access_key             S3 access key ID
+  s3_secret_key             S3 secret access key
+  s3_region                 S3 region (NULL for MinIO)
+  s3_use_ssl                Use HTTPS (default: ON)
+  s3_path_style             Path-style URLs for MinIO (default: OFF)
+  objstore_local_cache_max  Local cache size limit (default: 0 = unlimited)
+  objstore_wal_sync_threshold  WAL sync byte threshold (default: 1MB)
+  objstore_wal_sync_on_commit  Upload WAL on every commit (default: OFF)
+  replica_mode              Read-only replica (default: OFF)
+  replica_sync_interval     MANIFEST poll interval in us (default: 5000000)
 
 Dynamic (SET GLOBAL at runtime):
 
@@ -274,6 +300,8 @@ Dynamic (SET GLOBAL at runtime):
                             per-row granularity and wait-for-graph deadlock
                             detection. Enable for TPC-C or workloads needing
                             FOR UPDATE serialization semantics.
+  promote_primary           Set to ON to promote a replica to primary
+                            (trigger variable, resets to OFF after promotion)
 
 Session (SET SESSION tidesdb_...):
 

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,7 @@
 #   --list-engines              List storage engines that can be skipped and exit
 #   --rebuild-plugin             Rebuild only the TidesDB plugin (fast dev cycle)
 #   --pgo                       Enable Profile-Guided Optimization (3-phase build)
+#   --s3                        Build TidesDB with S3 object store connector (requires libcurl + OpenSSL)
 #   --help                      Show this help message
 #
 # Platform defaults:
@@ -167,6 +168,7 @@ SKIP_TIDESDB=false
 REBUILD_PLUGIN=false
 PGO_ENABLED=false
 SKIP_ENGINES=""
+WITH_S3=false
 
 # ── Ensure VCPKG_ROOT is set on Windows (needed even with --skip-deps) ────────
 if [[ "$OS" == "windows" ]]; then
@@ -246,6 +248,7 @@ while [[ $# -gt 0 ]]; do
         --skip-engines)     SKIP_ENGINES="$2";      shift 2 ;;
         --list-engines)     list_engines ;;
         --pgo)              PGO_ENABLED=true;       shift   ;;
+        --s3)               WITH_S3=true;           shift   ;;
         --help|-h)          usage ;;
         *) die "Unknown option: $1 (try --help)" ;;
     esac
@@ -471,6 +474,11 @@ build_tidesdb() {
         -DBUILD_SHARED_LIBS=ON
     )
 
+    if $WITH_S3; then
+        cmake_args+=(-DTIDESDB_WITH_S3=ON)
+        info "S3 object store connector enabled"
+    fi
+
     case "$OS" in
         macos)
             local sdk_root
@@ -550,6 +558,11 @@ build_mariadb() {
         -DWITH_MARIABACKUP=ON
         -DWITH_UNIT_TESTS=OFF
     )
+
+    # S3 object store connector for the plugin
+    if $WITH_S3; then
+        cmake_args+=(-DTIDESDB_WITH_S3=ON)
+    fi
 
     # Disable skipped engines
     if [[ -n "$SKIP_ENGINES" ]]; then

--- a/k8s/failover-controller.yaml
+++ b/k8s/failover-controller.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tidesdb-failover-script
+  namespace: tidesql
+data:
+  failover.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    PRIMARY_HOST="${PRIMARY_HOST:-tidesql-primary}"
+    PRIMARY_PORT="${PRIMARY_PORT:-3306}"
+    REPLICA_HOST="${REPLICA_HOST:-tidesql-replica}"
+    REPLICA_PORT="${REPLICA_PORT:-3306}"
+    CHECK_INTERVAL="${CHECK_INTERVAL:-5}"
+    FAILURE_THRESHOLD="${FAILURE_THRESHOLD:-3}"
+    MYSQL_USER="${MYSQL_USER:-root}"
+    MYSQL_PASSWORD="${MYSQL_PASSWORD:-}"
+
+    FAILURES=0
+
+    log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+    check_primary() {
+        mariadb -h "$PRIMARY_HOST" -P "$PRIMARY_PORT" \
+                -u "$MYSQL_USER" ${MYSQL_PASSWORD:+-p"$MYSQL_PASSWORD"} \
+                -e "SELECT 1" > /dev/null 2>&1
+    }
+
+    promote_replica() {
+        log "PROMOTING replica $REPLICA_HOST to primary"
+        mariadb -h "$REPLICA_HOST" -P "$REPLICA_PORT" \
+                -u "$MYSQL_USER" ${MYSQL_PASSWORD:+-p"$MYSQL_PASSWORD"} \
+                -e "SET GLOBAL tidesdb_promote_primary = ON" 2>&1
+        log "Promotion command sent"
+    }
+
+    log "TidesQL Failover Controller started"
+    log "Primary: $PRIMARY_HOST:$PRIMARY_PORT"
+    log "Replica: $REPLICA_HOST:$REPLICA_PORT"
+
+    while true; do
+        if check_primary; then
+            [ "$FAILURES" -gt 0 ] && log "Primary recovered after $FAILURES failures"
+            FAILURES=0
+        else
+            FAILURES=$((FAILURES + 1))
+            log "Primary check failed ($FAILURES/$FAILURE_THRESHOLD)"
+            if [ "$FAILURES" -ge "$FAILURE_THRESHOLD" ]; then
+                promote_replica
+                log "Failover complete. Exiting."
+                exit 0
+            fi
+        fi
+        sleep "$CHECK_INTERVAL"
+    done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tidesql-failover-controller
+  namespace: tidesql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tidesql-failover
+  template:
+    metadata:
+      labels:
+        app: tidesql-failover
+    spec:
+      containers:
+        - name: controller
+          image: mariadb:latest
+          command: ["bash", "/scripts/failover.sh"]
+          env:
+            - name: PRIMARY_HOST
+              value: "tidesql-primary"
+            - name: REPLICA_HOST
+              value: "tidesql-replica"
+            - name: CHECK_INTERVAL
+              value: "5"
+            - name: FAILURE_THRESHOLD
+              value: "3"
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+      volumes:
+        - name: scripts
+          configMap:
+            name: tidesdb-failover-script
+            defaultMode: 0755

--- a/k8s/failover.sh
+++ b/k8s/failover.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# TidesQL Failover Controller
+#
+# Monitors the primary MariaDB instance and promotes a replica
+# when the primary becomes unresponsive. Designed to run as a
+# sidecar container or CronJob in Kubernetes.
+#
+# Usage:
+#   ./failover.sh
+#
+# Environment variables:
+#   PRIMARY_HOST      Primary MariaDB host (default: tidesql-primary)
+#   PRIMARY_PORT      Primary MariaDB port (default: 3306)
+#   REPLICA_HOST      Replica MariaDB host (default: tidesql-replica)
+#   REPLICA_PORT      Replica MariaDB port (default: 3306)
+#   CHECK_INTERVAL    Seconds between health checks (default: 5)
+#   FAILURE_THRESHOLD Consecutive failures before promotion (default: 3)
+#   MYSQL_USER        MariaDB user for health checks (default: root)
+#   MYSQL_PASSWORD    MariaDB password (default: empty)
+
+set -euo pipefail
+
+PRIMARY_HOST="${PRIMARY_HOST:-tidesql-primary}"
+PRIMARY_PORT="${PRIMARY_PORT:-3306}"
+REPLICA_HOST="${REPLICA_HOST:-tidesql-replica}"
+REPLICA_PORT="${REPLICA_PORT:-3306}"
+CHECK_INTERVAL="${CHECK_INTERVAL:-5}"
+FAILURE_THRESHOLD="${FAILURE_THRESHOLD:-3}"
+MYSQL_USER="${MYSQL_USER:-root}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-}"
+
+FAILURES=0
+
+log() {
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+check_primary() {
+    if mariadb -h "$PRIMARY_HOST" -P "$PRIMARY_PORT" \
+               -u "$MYSQL_USER" ${MYSQL_PASSWORD:+-p"$MYSQL_PASSWORD"} \
+               -e "SELECT 1" > /dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+promote_replica() {
+    log "PROMOTING replica $REPLICA_HOST to primary"
+
+    # promote via SET GLOBAL
+    mariadb -h "$REPLICA_HOST" -P "$REPLICA_PORT" \
+            -u "$MYSQL_USER" ${MYSQL_PASSWORD:+-p"$MYSQL_PASSWORD"} \
+            -e "SET GLOBAL tidesdb_promote_primary = ON" 2>&1
+
+    if [ $? -eq 0 ]; then
+        log "PROMOTION SUCCESSFUL: $REPLICA_HOST is now primary"
+
+        # verify writes work
+        mariadb -h "$REPLICA_HOST" -P "$REPLICA_PORT" \
+                -u "$MYSQL_USER" ${MYSQL_PASSWORD:+-p"$MYSQL_PASSWORD"} \
+                -e "SELECT 'write_test'" > /dev/null 2>&1
+
+        log "Replica is accepting connections"
+    else
+        log "PROMOTION FAILED: could not promote $REPLICA_HOST"
+    fi
+}
+
+log "TidesQL Failover Controller started"
+log "Monitoring primary at $PRIMARY_HOST:$PRIMARY_PORT"
+log "Replica at $REPLICA_HOST:$REPLICA_PORT"
+log "Check interval: ${CHECK_INTERVAL}s, failure threshold: $FAILURE_THRESHOLD"
+
+while true; do
+    if check_primary; then
+        if [ "$FAILURES" -gt 0 ]; then
+            log "Primary recovered after $FAILURES failures"
+        fi
+        FAILURES=0
+    else
+        FAILURES=$((FAILURES + 1))
+        log "Primary health check failed ($FAILURES/$FAILURE_THRESHOLD)"
+
+        if [ "$FAILURES" -ge "$FAILURE_THRESHOLD" ]; then
+            log "Primary unreachable for $FAILURES consecutive checks"
+            promote_replica
+            # after promotion, exit so the controller can be restarted
+            # with the new primary as the target
+            log "Failover complete. Exiting controller."
+            exit 0
+        fi
+    fi
+
+    sleep "$CHECK_INTERVAL"
+done

--- a/k8s/primary.yaml
+++ b/k8s/primary.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tidesdb-s3-credentials
+  namespace: tidesql
+type: Opaque
+stringData:
+  access-key: "REPLACE_WITH_ACCESS_KEY"
+  secret-key: "REPLACE_WITH_SECRET_KEY"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tidesdb-primary-config
+  namespace: tidesql
+data:
+  tidesdb.cnf: |
+    [mariadb]
+    plugin-load-add=ha_tidesdb.so
+
+    # Object store
+    tidesdb_object_store_backend=S3
+    tidesdb_s3_endpoint=s3.amazonaws.com
+    tidesdb_s3_bucket=tidesdb-production
+    tidesdb_s3_region=us-east-1
+    tidesdb_s3_use_ssl=ON
+    tidesdb_s3_path_style=OFF
+    tidesdb_objstore_local_cache_max=536870912
+    tidesdb_objstore_wal_sync_threshold=1048576
+    tidesdb_objstore_wal_sync_on_commit=OFF
+
+    # Engine tuning
+    tidesdb_unified_memtable=ON
+    tidesdb_unified_memtable_write_buffer_size=134217728
+    tidesdb_block_cache_size=268435456
+    tidesdb_flush_threads=4
+    tidesdb_compaction_threads=4
+    tidesdb_log_level=INFO
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tidesql-primary
+  namespace: tidesql
+spec:
+  serviceName: tidesql-primary
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tidesql
+      role: primary
+  template:
+    metadata:
+      labels:
+        app: tidesql
+        role: primary
+    spec:
+      containers:
+        - name: mariadb
+          image: tidesdb/tidesql:latest
+          ports:
+            - containerPort: 3306
+              name: mysql
+          env:
+            - name: TIDESDB_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tidesdb-s3-credentials
+                  key: access-key
+            - name: TIDESDB_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tidesdb-s3-credentials
+                  key: secret-key
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mysql/conf.d/tidesdb.cnf
+              subPath: tidesdb.cnf
+            - name: data
+              mountPath: /var/lib/mysql
+          livenessProbe:
+            exec:
+              command: ["mariadb-admin", "ping", "-h", "localhost"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["mariadb", "-h", "localhost", "-e", "SELECT 1"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: tidesdb-primary-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 100Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tidesql-primary
+  namespace: tidesql
+spec:
+  type: ClusterIP
+  selector:
+    app: tidesql
+    role: primary
+  ports:
+    - port: 3306
+      targetPort: 3306
+      name: mysql

--- a/k8s/replica.yaml
+++ b/k8s/replica.yaml
@@ -1,0 +1,98 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tidesdb-replica-config
+  namespace: tidesql
+data:
+  tidesdb.cnf: |
+    [mariadb]
+    plugin-load-add=ha_tidesdb.so
+
+    # Object store (same bucket as primary)
+    tidesdb_object_store_backend=S3
+    tidesdb_s3_endpoint=s3.amazonaws.com
+    tidesdb_s3_bucket=tidesdb-production
+    tidesdb_s3_region=us-east-1
+    tidesdb_s3_use_ssl=ON
+    tidesdb_s3_path_style=OFF
+    tidesdb_objstore_local_cache_max=536870912
+
+    # Replica mode
+    tidesdb_replica_mode=ON
+    tidesdb_replica_sync_interval=1000000
+
+    # Engine tuning
+    tidesdb_unified_memtable=ON
+    tidesdb_unified_memtable_write_buffer_size=134217728
+    tidesdb_block_cache_size=268435456
+    tidesdb_flush_threads=2
+    tidesdb_compaction_threads=2
+    tidesdb_log_level=INFO
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tidesql-replica
+  namespace: tidesql
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: tidesql
+      role: replica
+  template:
+    metadata:
+      labels:
+        app: tidesql
+        role: replica
+    spec:
+      containers:
+        - name: mariadb
+          image: tidesdb/tidesql:latest
+          ports:
+            - containerPort: 3306
+              name: mysql
+          env:
+            - name: TIDESDB_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tidesdb-s3-credentials
+                  key: access-key
+            - name: TIDESDB_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tidesdb-s3-credentials
+                  key: secret-key
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mysql/conf.d/tidesdb.cnf
+              subPath: tidesdb.cnf
+            - name: cache
+              mountPath: /var/lib/mysql
+          readinessProbe:
+            exec:
+              command: ["mariadb", "-h", "localhost", "-e", "SELECT 1"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: tidesdb-replica-config
+        - name: cache
+          emptyDir:
+            sizeLimit: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tidesql-replica
+  namespace: tidesql
+spec:
+  type: ClusterIP
+  selector:
+    app: tidesql
+    role: replica
+  ports:
+    - port: 3306
+      targetPort: 3306
+      name: mysql

--- a/tidesdb/CMakeLists.txt
+++ b/tidesdb/CMakeLists.txt
@@ -148,8 +148,24 @@ IF(WIN32)
   ENDIF()
 ENDIF()
 
+############# Optional S3 object store connector #############
+OPTION(TIDESDB_WITH_S3 "Enable S3-compatible object store connector" OFF)
+IF(TIDESDB_WITH_S3)
+  FIND_PACKAGE(CURL REQUIRED)
+  FIND_PACKAGE(OpenSSL REQUIRED)
+  LIST(APPEND TIDESDB_LIBS CURL::libcurl OpenSSL::SSL OpenSSL::Crypto)
+  MESSAGE(STATUS "TidesDB: S3 object store connector enabled")
+ENDIF()
+
 ############# Define the storage engine using MariaDB's MYSQL_ADD_PLUGIN macro #############
 MYSQL_ADD_PLUGIN(tidesdb ha_tidesdb.cc STORAGE_ENGINE MODULE_ONLY LINK_LIBRARIES ${TIDESDB_LIBS})
+
+############# S3 compile definition for the plugin #############
+IF(TIDESDB_WITH_S3)
+  IF(TARGET tidesdb)
+    TARGET_COMPILE_DEFINITIONS(tidesdb PRIVATE TIDESDB_WITH_S3)
+  ENDIF()
+ENDIF()
 
 ############# Apply sanitizer flags to the plugin target only #############
 IF(TIDESDB_SANITIZER_COMPILE_FLAGS)

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -20,6 +20,9 @@ extern "C"
 {
 #define XXH_INLINE_ALL
 #include <tidesdb/xxhash.h>
+#ifdef TIDESDB_WITH_S3
+#include <tidesdb/objstore_s3.h>
+#endif
 }
 
 #include <mysql/plugin.h>
@@ -88,6 +91,9 @@ static int tdb_rc_to_ha(int rc, const char *ctx)
             return HA_ERR_KEY_NOT_FOUND;
         case TDB_ERR_EXISTS:
             return HA_ERR_FOUND_DUPP_KEY;
+        case TDB_ERR_READONLY:
+            sql_print_warning("TIDESDB: %s: write rejected (replica mode)", ctx);
+            return HA_ERR_READ_ONLY_TRANSACTION;
         default:
             sql_print_warning("TIDESDB: %s: unexpected TidesDB error rc=%d", ctx, rc);
             return HA_ERR_GENERIC;
@@ -554,6 +560,115 @@ static MYSQL_SYSVAR_STR(data_home_dir, srv_data_home_dir, PLUGIN_VAR_RQCMDARG | 
                         "must be set before server startup (read-only)",
                         NULL, NULL, NULL);
 
+/* ******************** Object Store Configuration ******************** */
+
+/* Object store backend: 0=LOCAL (no object store), 1=S3 */
+static ulong srv_object_store_backend = 0;
+static const char *object_store_backend_names[] = {"LOCAL", "S3", NullS};
+static TYPELIB object_store_backend_typelib = {array_elements(object_store_backend_names) - 1,
+                                               "object_store_backend_typelib",
+                                               object_store_backend_names, NULL};
+static MYSQL_SYSVAR_ENUM(object_store_backend, srv_object_store_backend,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                         "Object store backend (LOCAL=disabled, S3=S3-compatible)", NULL, NULL, 0,
+                         &object_store_backend_typelib);
+
+static char *srv_s3_endpoint = NULL;
+static MYSQL_SYSVAR_STR(s3_endpoint, srv_s3_endpoint, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                        "S3 endpoint (e.g. s3.amazonaws.com or minio.local:9000)", NULL, NULL,
+                        NULL);
+
+static char *srv_s3_bucket = NULL;
+static MYSQL_SYSVAR_STR(s3_bucket, srv_s3_bucket, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                        "S3 bucket name", NULL, NULL, NULL);
+
+static char *srv_s3_prefix = NULL;
+static MYSQL_SYSVAR_STR(s3_prefix, srv_s3_prefix, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                        "S3 key prefix (e.g. production/db1/)", NULL, NULL, NULL);
+
+static char *srv_s3_access_key = NULL;
+static MYSQL_SYSVAR_STR(s3_access_key, srv_s3_access_key, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                        "S3 access key ID", NULL, NULL, NULL);
+
+static char *srv_s3_secret_key = NULL;
+static MYSQL_SYSVAR_STR(s3_secret_key, srv_s3_secret_key, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                        "S3 secret access key", NULL, NULL, NULL);
+
+static char *srv_s3_region = NULL;
+static MYSQL_SYSVAR_STR(s3_region, srv_s3_region, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                        "S3 region (e.g. us-east-1, NULL for MinIO)", NULL, NULL, NULL);
+
+static my_bool srv_s3_use_ssl = 1;
+static MYSQL_SYSVAR_BOOL(s3_use_ssl, srv_s3_use_ssl, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                         "Use HTTPS for S3 connections (default ON)", NULL, NULL, 1);
+
+static my_bool srv_s3_path_style = 0;
+static MYSQL_SYSVAR_BOOL(s3_path_style, srv_s3_path_style,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                         "Use path-style S3 URLs (required for MinIO, default OFF)", NULL, NULL, 0);
+
+static ulonglong srv_objstore_local_cache_max = 0;
+static MYSQL_SYSVAR_ULONGLONG(
+    objstore_local_cache_max, srv_objstore_local_cache_max,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+    "Maximum local cache size in bytes for object store mode (0=unlimited)", NULL, NULL, 0, 0,
+    ULONGLONG_MAX, 0);
+
+static ulonglong srv_objstore_wal_sync_threshold = 1048576;
+static MYSQL_SYSVAR_ULONGLONG(
+    objstore_wal_sync_threshold, srv_objstore_wal_sync_threshold,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+    "Sync active WAL to object store when it grows by this many bytes (default 1MB, 0=disable)",
+    NULL, NULL, 1048576, 0, ULONGLONG_MAX, 0);
+
+static my_bool srv_objstore_wal_sync_on_commit = 0;
+static MYSQL_SYSVAR_BOOL(objstore_wal_sync_on_commit, srv_objstore_wal_sync_on_commit,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                         "Upload WAL after every commit for RPO=0 replication (default OFF)", NULL,
+                         NULL, 0);
+
+static my_bool srv_replica_mode = 0;
+static MYSQL_SYSVAR_BOOL(replica_mode, srv_replica_mode, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                         "Enable read-only replica mode (default OFF)", NULL, NULL, 0);
+
+static ulonglong srv_replica_sync_interval = 5000000;
+static MYSQL_SYSVAR_ULONGLONG(
+    replica_sync_interval, srv_replica_sync_interval, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+    "MANIFEST poll interval for replica sync in microseconds (default 5s)", NULL, NULL, 5000000,
+    100000, ULONGLONG_MAX, 0);
+
+/* Promote replica to primary -- trigger variable (like backup_dir) */
+static my_bool srv_promote_primary = 0;
+static void tidesdb_promote_primary_update(THD *thd, struct st_mysql_sys_var *, void *var_ptr,
+                                           const void *save)
+{
+    my_bool val = *static_cast<const my_bool *>(save);
+    if (!val) return; /* only act on SET ... = ON */
+
+    if (!tdb_global)
+    {
+        my_error(ER_UNKNOWN_ERROR, MYF(0));
+        return;
+    }
+
+    int rc = tidesdb_promote_to_primary(tdb_global);
+    if (rc == TDB_SUCCESS)
+    {
+        sql_print_information("TIDESDB: Replica promoted to primary successfully");
+    }
+    else
+    {
+        sql_print_error("TIDESDB: Failed to promote replica (err=%d)", rc);
+    }
+
+    /* reset to OFF so it can be triggered again */
+    *static_cast<my_bool *>(var_ptr) = 0;
+}
+
+static MYSQL_SYSVAR_BOOL(promote_primary, srv_promote_primary, PLUGIN_VAR_RQCMDARG,
+                         "Set to ON to promote this replica to primary (trigger, resets to OFF)",
+                         NULL, tidesdb_promote_primary_update, 0);
+
 /* ******************** Online backup via system variable ******************** */
 
 static char *srv_backup_dir = NULL;
@@ -718,6 +833,21 @@ static struct st_mysql_sys_var *tidesdb_system_variables[] = {
     MYSQL_SYSVAR(unified_memtable_write_buffer_size),
     MYSQL_SYSVAR(unified_memtable_sync_mode),
     MYSQL_SYSVAR(unified_memtable_sync_interval),
+    MYSQL_SYSVAR(object_store_backend),
+    MYSQL_SYSVAR(s3_endpoint),
+    MYSQL_SYSVAR(s3_bucket),
+    MYSQL_SYSVAR(s3_prefix),
+    MYSQL_SYSVAR(s3_access_key),
+    MYSQL_SYSVAR(s3_secret_key),
+    MYSQL_SYSVAR(s3_region),
+    MYSQL_SYSVAR(s3_use_ssl),
+    MYSQL_SYSVAR(s3_path_style),
+    MYSQL_SYSVAR(objstore_local_cache_max),
+    MYSQL_SYSVAR(objstore_wal_sync_threshold),
+    MYSQL_SYSVAR(objstore_wal_sync_on_commit),
+    MYSQL_SYSVAR(replica_mode),
+    MYSQL_SYSVAR(replica_sync_interval),
+    MYSQL_SYSVAR(promote_primary),
     NULL};
 
 /* ******************** Table options (per-table CF config) ******************** */
@@ -1313,7 +1443,7 @@ static bool tidesdb_show_status(handlerton *hton, THD *thd, stat_print_fn *print
     memset(&cache_st, 0, sizeof(cache_st));
     tidesdb_get_cache_stats(tdb_global, &cache_st);
 
-    char buf[4096];
+    char buf[8192];
     int pos = 0;
 
     pos += snprintf(buf + pos, sizeof(buf) - pos,
@@ -1362,6 +1492,25 @@ static bool tidesdb_show_status(handlerton *hton, THD *thd, stat_print_fn *print
     pos += snprintf(buf + pos, sizeof(buf) - pos, "Hit rate: %.1f%%\n", cache_st.hit_rate * 100.0);
     pos += snprintf(buf + pos, sizeof(buf) - pos, "Partitions: %lu\n",
                     (unsigned long)cache_st.num_partitions);
+
+    /* Object store stats */
+    if (db_st.object_store_enabled)
+    {
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "\n--- Object Store ---\n");
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "Connector: %s\n",
+                        db_st.object_store_connector ? db_st.object_store_connector : "unknown");
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "Total uploads: %lu\n",
+                        (unsigned long)db_st.total_uploads);
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "Upload failures: %lu\n",
+                        (unsigned long)db_st.total_upload_failures);
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "Upload queue depth: %lu\n",
+                        (unsigned long)db_st.upload_queue_depth);
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "Local cache: %lu / %lu bytes (%d files)\n",
+                        (unsigned long)db_st.local_cache_bytes_used,
+                        (unsigned long)db_st.local_cache_bytes_max, db_st.local_cache_num_files);
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "Replica mode: %s\n",
+                        db_st.replica_mode ? "ON" : "OFF");
+    }
 
     /* Last conflict info */
     mysql_mutex_lock(&last_conflict_mutex);
@@ -1457,6 +1606,56 @@ static int tidesdb_init_func(void *p)
     cfg.unified_memtable_sync_interval_us = (uint64_t)srv_unified_memtable_sync_interval;
     cfg.unified_memtable_skip_list_max_level = 0;      /* 0 = library default */
     cfg.unified_memtable_skip_list_probability = 0.0f; /* 0 = library default */
+
+    /* Object store connector setup */
+    tidesdb_objstore_t *objstore_connector = NULL;
+    tidesdb_objstore_config_t objstore_cfg;
+
+    if (srv_object_store_backend == 1) /* S3 */
+    {
+#ifdef TIDESDB_WITH_S3
+        if (!srv_s3_endpoint || !srv_s3_bucket || !srv_s3_access_key || !srv_s3_secret_key)
+        {
+            sql_print_error(
+                "TIDESDB: S3 backend requires s3_endpoint, s3_bucket, "
+                "s3_access_key, and s3_secret_key");
+            DBUG_RETURN(1);
+        }
+
+        objstore_connector = tidesdb_objstore_s3_create(
+            srv_s3_endpoint, srv_s3_bucket, srv_s3_prefix, srv_s3_access_key, srv_s3_secret_key,
+            srv_s3_region, srv_s3_use_ssl ? 1 : 0, srv_s3_path_style ? 1 : 0);
+
+        if (!objstore_connector)
+        {
+            sql_print_error("TIDESDB: Failed to create S3 connector for %s/%s", srv_s3_endpoint,
+                            srv_s3_bucket);
+            DBUG_RETURN(1);
+        }
+
+        sql_print_information("TIDESDB: S3 connector created (endpoint=%s, bucket=%s, ssl=%s)",
+                              srv_s3_endpoint, srv_s3_bucket, srv_s3_use_ssl ? "yes" : "no");
+#else
+        sql_print_error(
+            "TIDESDB: S3 backend requested but TidesDB was not built with "
+            "-DTIDESDB_WITH_S3=ON");
+        DBUG_RETURN(1);
+#endif
+    }
+
+    if (objstore_connector)
+    {
+        objstore_cfg = tidesdb_objstore_default_config();
+        objstore_cfg.local_cache_max_bytes = (size_t)srv_objstore_local_cache_max;
+        objstore_cfg.wal_sync_threshold_bytes = (size_t)srv_objstore_wal_sync_threshold;
+        objstore_cfg.wal_sync_on_commit = srv_objstore_wal_sync_on_commit ? 1 : 0;
+        objstore_cfg.replica_mode = srv_replica_mode ? 1 : 0;
+        objstore_cfg.replica_sync_interval_us = (uint64_t)srv_replica_sync_interval;
+        objstore_cfg.replica_replay_wal = 1;
+
+        cfg.object_store = objstore_connector;
+        cfg.object_store_config = &objstore_cfg;
+    }
 
     int rc = tidesdb_open(&cfg, &tdb_global);
     if (rc != TDB_SUCCESS)
@@ -2718,7 +2917,10 @@ int ha_tidesdb::iter_read_current(uchar *buf)
     {
         uint8_t *key = NULL;
         size_t key_size = 0;
-        if (tidesdb_iter_key(scan_iter, &key, &key_size) != TDB_SUCCESS) return HA_ERR_END_OF_FILE;
+        uint8_t *value = NULL;
+        size_t value_size = 0;
+        if (tidesdb_iter_key_value(scan_iter, &key, &key_size, &value, &value_size) != TDB_SUCCESS)
+            return HA_ERR_END_OF_FILE;
 
         /* We skip non-data keys (meta namespace) */
         if (!is_data_key(key, key_size))
@@ -2731,14 +2933,8 @@ int ha_tidesdb::iter_read_current(uchar *buf)
         current_pk_len_ = (uint)(key_size - 1);
         memcpy(current_pk_buf_, key + 1, current_pk_len_);
 
-        uint8_t *value = NULL;
-        size_t value_size = 0;
-        if (tidesdb_iter_value(scan_iter, &value, &value_size) != TDB_SUCCESS)
-            return HA_ERR_END_OF_FILE;
-
         if (!share->has_blobs && !share->encrypted)
         {
-            /* We just unpack directly from iterator buffer (no copy) */
             deserialize_row(buf, (const uchar *)value, value_size);
         }
         else
@@ -3074,6 +3270,7 @@ int ha_tidesdb::rnd_init(bool scan)
     DBUG_ENTER("ha_tidesdb::rnd_init");
 
     current_pk_len_ = 0;
+    scan_dir_ = DIR_NONE;
 
     /* Lazy txn -- we ensure stmt_txn exists */
     {
@@ -3131,11 +3328,13 @@ int ha_tidesdb::rnd_next(uchar *buf)
 {
     DBUG_ENTER("ha_tidesdb::rnd_next");
 
+    /* advance past the last-read entry.  on the first call after rnd_init
+     * the iterator is already positioned at the first data key by the seek
+     * in rnd_init, so we skip the advance (scan_dir_ == DIR_NONE). */
+    if (scan_dir_ != DIR_NONE) tidesdb_iter_next(scan_iter);
+
     int ret = iter_read_current(buf);
-    if (ret == 0)
-    {
-        tidesdb_iter_next(scan_iter);
-    }
+    if (ret == 0) scan_dir_ = DIR_FORWARD;
 
     DBUG_RETURN(ret);
 }
@@ -3323,11 +3522,7 @@ int ha_tidesdb::index_read_map(uchar *buf, const uchar *key, key_part_map keypar
             }
             tidesdb_iter_seek(scan_iter, seek_key, seek_len);
             int ret = iter_read_current(buf);
-            if (ret == 0)
-            {
-                tidesdb_iter_next(scan_iter);
-                scan_dir_ = DIR_FORWARD;
-            }
+            if (ret == 0) scan_dir_ = DIR_FORWARD;
             DBUG_RETURN(ret);
         }
 
@@ -3352,11 +3547,7 @@ int ha_tidesdb::index_read_map(uchar *buf, const uchar *key, key_part_map keypar
             }
 
             int ret = iter_read_current(buf);
-            if (ret == 0)
-            {
-                tidesdb_iter_next(scan_iter);
-                scan_dir_ = DIR_FORWARD;
-            }
+            if (ret == 0) scan_dir_ = DIR_FORWARD;
             DBUG_RETURN(ret);
         }
         else if (find_flag == HA_READ_KEY_OR_PREV || find_flag == HA_READ_BEFORE_KEY ||
@@ -3380,11 +3571,7 @@ int ha_tidesdb::index_read_map(uchar *buf, const uchar *key, key_part_map keypar
         /* Fallback is to seek forward */
         tidesdb_iter_seek(scan_iter, seek_key, seek_len);
         int ret = iter_read_current(buf);
-        if (ret == 0)
-        {
-            tidesdb_iter_next(scan_iter);
-            scan_dir_ = DIR_FORWARD;
-        }
+        if (ret == 0) scan_dir_ = DIR_FORWARD;
         DBUG_RETURN(ret);
     }
     else
@@ -3474,17 +3661,8 @@ int ha_tidesdb::index_read_map(uchar *buf, const uchar *key, key_part_map keypar
                 ret = fetch_row_by_pk(scan_txn, ik + idx_col_len, (uint)(iks - idx_col_len), buf);
             if (ret == 0)
             {
-                if (is_backward)
-                {
-                    scan_dir_ = DIR_BACKWARD;
-                }
-                else
-                {
-                    tidesdb_iter_next(scan_iter);
-                    scan_dir_ = DIR_FORWARD;
-                }
+                scan_dir_ = is_backward ? DIR_BACKWARD : DIR_FORWARD;
             }
-
             DBUG_RETURN(ret);
         }
     }
@@ -3505,21 +3683,22 @@ int ha_tidesdb::index_next(uchar *buf)
         uint seek_len = build_data_key(current_pk_buf_, current_pk_len_, seek_key);
         tidesdb_iter_seek(scan_iter, seek_key, seek_len);
         if (tidesdb_iter_valid(scan_iter)) tidesdb_iter_next(scan_iter);
-        /* Iterator is now one ahead -- matches DIR_FORWARD contract */
+        /* iterator is now past the PK exact match -- advance+read below */
     }
     else
     {
         int irc = ensure_scan_iter();
         if (irc) DBUG_RETURN(irc);
-        /* Direction switch -- if last op was backward, iterator is at the
-           last-read row.  We skip past it so we read the next one. */
-        if (scan_dir_ == DIR_BACKWARD) tidesdb_iter_next(scan_iter);
+        /* advance past the last-read entry (iterator stays at current
+         * with no pre-advance).  On the first call after index_first
+         * sets DIR_NONE, the iterator is already at the correct position
+         * so we must not advance. */
+        if (scan_dir_ != DIR_NONE) tidesdb_iter_next(scan_iter);
     }
 
     if (is_pk)
     {
         int ret = iter_read_current(buf);
-        if (ret == 0) tidesdb_iter_next(scan_iter);
         scan_dir_ = DIR_FORWARD;
         DBUG_RETURN(ret);
     }
@@ -3554,7 +3733,6 @@ int ha_tidesdb::index_next(uchar *buf)
                 ret = 0;
             else
                 ret = fetch_row_by_pk(scan_txn, ik + idx_key_len, (uint)(iks - idx_key_len), buf);
-            if (ret == 0) tidesdb_iter_next(scan_iter);
             scan_dir_ = DIR_FORWARD;
             DBUG_RETURN(ret);
         }
@@ -3575,15 +3753,15 @@ int ha_tidesdb::index_prev(uchar *buf)
         uchar seek_key[MAX_KEY_LENGTH + 2];
         uint seek_len = build_data_key(current_pk_buf_, current_pk_len_, seek_key);
         tidesdb_iter_seek(scan_iter, seek_key, seek_len);
-        /* Iterator is at the matched key -- fall through to prev() */
+        /* iterator is at the matched key -- fall through to prev() */
     }
     else
     {
         int irc = ensure_scan_iter();
         if (irc) DBUG_RETURN(irc);
-        if (scan_dir_ == DIR_FORWARD) tidesdb_iter_prev(scan_iter);
     }
 
+    /* advance backward past the last-read entry */
     tidesdb_iter_prev(scan_iter);
 
     bool is_pk = share->has_user_pk && active_index == share->pk_index;
@@ -3653,11 +3831,7 @@ int ha_tidesdb::index_first(uchar *buf)
         uint8_t data_prefix = KEY_NS_DATA;
         tidesdb_iter_seek(scan_iter, &data_prefix, 1);
         int ret = iter_read_current(buf);
-        if (ret == 0)
-        {
-            tidesdb_iter_next(scan_iter);
-            scan_dir_ = DIR_FORWARD;
-        }
+        if (ret == 0) scan_dir_ = DIR_FORWARD;
         DBUG_RETURN(ret);
     }
     else
@@ -3728,7 +3902,11 @@ int ha_tidesdb::index_next_same(uchar *buf, const uchar *key, uint keylen)
 
         /* Partial PK prefix on a composite PK -- iterate through data keys
            that share this prefix-- KEY_NS_DATA + comparable_pk_prefix... */
-        if (!scan_iter || !tidesdb_iter_valid(scan_iter)) DBUG_RETURN(HA_ERR_END_OF_FILE);
+        if (!scan_iter) DBUG_RETURN(HA_ERR_END_OF_FILE);
+
+        /* advance past the last-read entry */
+        tidesdb_iter_next(scan_iter);
+        if (!tidesdb_iter_valid(scan_iter)) DBUG_RETURN(HA_ERR_END_OF_FILE);
 
         uint8_t *ik = NULL;
         size_t iks = 0;
@@ -3741,20 +3919,18 @@ int ha_tidesdb::index_next_same(uchar *buf, const uchar *key, uint keylen)
             DBUG_RETURN(HA_ERR_END_OF_FILE);
 
         int ret = iter_read_current(buf);
-        if (ret == 0)
-        {
-            tidesdb_iter_next(scan_iter);
-            scan_dir_ = DIR_FORWARD;
-        }
+        if (ret == 0) scan_dir_ = DIR_FORWARD;
         DBUG_RETURN(ret);
     }
 
-    /* Secondary index -- ICP loop -- we skip entries that fail the pushed
-       condition without the expensive PK point-lookup. */
+    /* Secondary index -- advance past the last-read entry, then ICP loop */
+    if (!scan_iter) DBUG_RETURN(HA_ERR_END_OF_FILE);
+    tidesdb_iter_next(scan_iter);
+
     uint idx_col_len = share->idx_comp_key_len[active_index];
     for (;;)
     {
-        if (!scan_iter || !tidesdb_iter_valid(scan_iter)) DBUG_RETURN(HA_ERR_END_OF_FILE);
+        if (!tidesdb_iter_valid(scan_iter)) DBUG_RETURN(HA_ERR_END_OF_FILE);
 
         uint8_t *ik = NULL;
         size_t iks = 0;
@@ -3782,7 +3958,6 @@ int ha_tidesdb::index_next_same(uchar *buf, const uchar *key, uint keylen)
             ret = 0;
         else
             ret = fetch_row_by_pk(scan_txn, ik + idx_col_len, (uint)(iks - idx_col_len), buf);
-        if (ret == 0) tidesdb_iter_next(scan_iter);
         DBUG_RETURN(ret);
     }
 }
@@ -5632,8 +5807,8 @@ maria_declare_plugin(tidesdb){
     PLUGIN_LICENSE_GPL,
     tidesdb_init_func,
     tidesdb_deinit_func,
-    0x40001,
+    0x40100,
     NULL,
     tidesdb_system_variables,
-    "4.0.1",
+    "4.1.0",
     MariaDB_PLUGIN_MATURITY_GAMMA} maria_declare_plugin_end;


### PR DESCRIPTION
Introduce S3-backed object storage and replica mode support with 16 new system variables covering endpoint, bucket, credentials, key prefix, SSL, path style, local cache limit, WAL sync threshold, WAL sync on commit, replica mode, and replica sync interval. tidesdb_init_func creates an S3 connector when tidesdb_object_store_backend is set to S3 and passes the objstore config to tidesdb_open. S3 connector creation is conditionally compiled under TIDESDB_WITH_S3.

Add tidesdb_promote_primary trigger variable that calls tidesdb_promote_to_primary when set to ON via SQL, then resets to OFF. This enables Kubernetes failover where a controller health-checks the primary and promotes a replica with SET GLOBAL tidesdb_promote_primary = ON. Map TDB_ERR_READONLY to HA_ERR_READ_ONLY_TRANSACTION for clean SQL error reporting on replicas.

Extend SHOW ENGINE TIDESDB STATUS with an object store section showing connector name, total uploads, upload failures, queue depth, local cache usage, and replica mode.

Remove iterator pre-advance from all read paths. The old contract called tidesdb_iter_next after every successful read to position one entry ahead, which triggered a full block deserialize via tidesdb_merge_source_advance on every index_read_map even when the next operation was a seek to a different key. The new contract keeps the iterator at the last-read entry: index_next and index_next_same advance before reading, index_prev retreats before reading, and direction switch adjustments are no longer needed.

Use tidesdb_iter_key_value in iter_read_current to get key and value in a single call instead of separate tidesdb_iter_key + tidesdb_iter_value. Adjust prefix len to 0 for full key mode in library.