### PR TITLE
TideSQL 4 PATCH (v4.1.1)

### DIFF
--- a/README
+++ b/README
@@ -213,7 +213,8 @@ Core:
 - START TRANSACTION WITH CONSISTENT SNAPSHOT
 - Lock-free concurrency (no THR_LOCK, TidesDB handles isolation internally)
 - Optional pessimistic row locking (tidesdb_pessimistic_locking=ON) for
-  workloads that depend on SELECT ... FOR UPDATE serialization (e.g. TPC-C)
+  workloads that depend on row-level serialization (e.g. TPC-C).
+  Locks are acquired by SELECT ... FOR UPDATE, UPDATE, DELETE, and INSERT
 - LSM-tree storage with optional B+tree SSTable format
 - Compression (NONE, LZ4, LZ4_FAST, ZSTD, Snappy)
 - Bloom filters for fast key lookups
@@ -273,7 +274,6 @@ Read-only (set at startup):
   unified_memtable_write_buffer_size  Write buffer for unified memtable (default: 128MB)
   unified_memtable_sync_mode         NONE/INTERVAL/FULL for unified WAL (default: FULL)
   unified_memtable_sync_interval     Sync interval in µs for INTERVAL mode (default: 128000)
-  row_lock_stripes          Legacy compat; lock table uses 256 hash partitions
   object_store_backend      LOCAL or S3 (default: LOCAL)
   s3_endpoint               S3 endpoint (e.g. s3.amazonaws.com)
   s3_bucket                 S3 bucket name
@@ -294,12 +294,13 @@ Dynamic (SET GLOBAL at runtime):
   backup_dir                Set to a path to trigger online backup
   checkpoint_dir            Set to a path to trigger hard-link checkpoint
   print_all_conflicts       Log all TDB_ERR_CONFLICT events (default: OFF)
-  pessimistic_locking       Enable plugin-level row locks for SELECT...FOR UPDATE
-                            in multi-statement transactions (default: OFF).
-                            Uses a partitioned hash-table lock manager with
-                            per-row granularity and wait-for-graph deadlock
-                            detection. Enable for TPC-C or workloads needing
-                            FOR UPDATE serialization semantics.
+  pessimistic_locking       Enable plugin-level row locks for SELECT...FOR UPDATE,
+                            UPDATE, DELETE, and INSERT (default: OFF). All
+                            write-intent statements acquire per-row locks,
+                            including autocommit. Uses a partitioned hash-table
+                            lock manager with wait-for-graph deadlock detection.
+                            Locks can cover non-existing PK values. Enable for
+                            TPC-C or workloads needing row-level serialization.
   promote_primary           Set to ON to promote a replica to primary
                             (trigger variable, resets to OFF after promotion)
 
@@ -394,7 +395,7 @@ Run specific test:
 
   perl mtr --suite=tidesdb tidesdb_crud
 
-Available tests (30 total):
+Available tests (32 total):
   tidesdb_alter_crash         Crash safety during ALTER TABLE operations
   tidesdb_analyze             ANALYZE TABLE with CF statistics output
   tidesdb_backup              Online backup via tidesdb_backup_dir
@@ -415,6 +416,8 @@ Available tests (30 total):
   tidesdb_options             Table and field options
   tidesdb_partition           RANGE/LIST/HASH/KEY partitioning
   tidesdb_per_index_btree     Per-index USE_BTREE option
+  tidesdb_pessimistic_forupdate    SELECT FOR UPDATE serialization (pessimistic locking)
+  tidesdb_pessimistic_insert_lock  Pessimistic locking edge cases (non-existing rows, INSERT)
   tidesdb_pk_index            Primary key and secondary index scans
   tidesdb_rename              Table rename
   tidesdb_replace_iodku       REPLACE INTO and INSERT ON DUPLICATE KEY UPDATE
@@ -424,7 +427,7 @@ Available tests (30 total):
   tidesdb_tpcc_contention     TPC-C district counter contention (pessimistic locking)
   tidesdb_ttl                 Time-to-live expiration
   tidesdb_vcol                Virtual/generated columns
-  tidesdb_write_pressure      oltp_write_only pressure (multi-connection)
+  tidesdb_write_pressure          oltp_write_only pressure (multi-connection)
 
 Run with verbose output:
 

--- a/mysql-test/suite/tidesdb/r/tidesdb_pessimistic_insert_lock.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_pessimistic_insert_lock.result
@@ -1,0 +1,181 @@
+call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+#
+# Setup
+#
+CREATE TABLE t (
+i INT,
+PRIMARY KEY (i)
+) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+connect  conA, localhost, root,,;
+connect  conB, localhost, root,,;
+#
+# TEST 1: SELECT FOR UPDATE on non-existing row blocks DELETE
+#   Connection A locks i=15 (does not exist).
+#   Connection B deletes i=2 (succeeds immediately),
+#   then tries to delete i=15 (must block).
+#
+connection conA;
+BEGIN;
+SELECT * FROM t WHERE i = 15 FOR UPDATE;
+i
+connection conB;
+DELETE FROM t WHERE i = 2;
+DELETE FROM t WHERE i = 15;
+connection conA;
+COMMIT;
+connection conB;
+connection default;
+# i=2 and i=15 both deleted (i=15 was no-op but lock was respected)
+SELECT * FROM t ORDER BY i;
+i
+1
+3
+4
+5
+#
+# TEST 2: DELETE acquires a lock that blocks another DELETE
+#   Connection A deletes i=3 inside a transaction.
+#   Connection B deletes i=4 (succeeds immediately),
+#   then tries to delete i=3 (must block until A commits).
+#
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+connection conA;
+BEGIN;
+DELETE FROM t WHERE i = 3;
+connection conB;
+DELETE FROM t WHERE i = 4;
+DELETE FROM t WHERE i = 3;
+connection conA;
+COMMIT;
+connection conB;
+connection default;
+# i=3 and i=4 both deleted
+SELECT * FROM t ORDER BY i;
+i
+1
+2
+5
+#
+# TEST 3: UPDATE acquires a lock that blocks another UPDATE
+#
+DROP TABLE t;
+CREATE TABLE t (i INT, v INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
+connection conA;
+BEGIN;
+UPDATE t SET v = 99 WHERE i = 3;
+connection conB;
+UPDATE t SET v = 88 WHERE i = 2;
+UPDATE t SET v = 77 WHERE i = 3;
+connection conA;
+COMMIT;
+connection conB;
+connection default;
+# conA set v=99, then conB overwrote with v=77
+SELECT * FROM t ORDER BY i;
+i	v
+1	10
+2	88
+3	77
+#
+# TEST 4: INSERT blocked by SELECT FOR UPDATE on non-existing key
+#   This is the critical fix -- previously INSERT bypassed the lock.
+#   Connection A does SELECT FOR UPDATE on i=15 (non-existing).
+#   Connection B tries INSERT i=15 (must block until A commits).
+#
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+connection conA;
+BEGIN;
+SELECT * FROM t WHERE i = 15 FOR UPDATE;
+i
+connection conB;
+INSERT INTO t VALUES (15);
+connection conA;
+COMMIT;
+connection conB;
+connection default;
+# i=15 now exists (inserted by conB after conA released the lock)
+SELECT * FROM t WHERE i >= 10 ORDER BY i;
+i
+15
+#
+# TEST 5: INSERT blocked by DELETE on existing row
+#   Connection A deletes i=3 inside a transaction.
+#   Connection B tries to INSERT i=3 (must block).
+#
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+connection conA;
+BEGIN;
+DELETE FROM t WHERE i = 3;
+connection conB;
+INSERT INTO t VALUES (3);
+connection conA;
+COMMIT;
+connection conB;
+connection default;
+# i=3 was deleted by conA, then re-inserted by conB
+SELECT * FROM t ORDER BY i;
+i
+1
+2
+3
+4
+5
+#
+# TEST 6: Concurrent INSERTs on different keys do not block
+#
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+connection conA;
+BEGIN;
+INSERT INTO t VALUES (100);
+connection conB;
+INSERT INTO t VALUES (200);
+connection conA;
+COMMIT;
+connection default;
+# Both inserts succeeded without blocking
+SELECT * FROM t ORDER BY i;
+i
+100
+200
+#
+# TEST 7: Autocommit UPDATE blocked by SELECT FOR UPDATE
+#
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+connection conA;
+BEGIN;
+SELECT * FROM t WHERE i = 3 FOR UPDATE;
+i
+3
+connection conB;
+UPDATE t SET i = 33 WHERE i = 3;
+connection conA;
+COMMIT;
+connection conB;
+connection default;
+# conA released lock, then conB's autocommit UPDATE renamed i=3 to i=33
+SELECT * FROM t ORDER BY i;
+i
+1
+2
+4
+5
+33
+#
+# Cleanup
+#
+disconnect conA;
+disconnect conB;
+connection default;
+DROP TABLE t;
+# Done.

--- a/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_insert_lock.opt
+++ b/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_insert_lock.opt
@@ -1,0 +1,1 @@
+--tidesdb-pessimistic-locking=ON

--- a/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_insert_lock.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_insert_lock.test
@@ -1,0 +1,227 @@
+--source include/have_tidesdb.inc
+#
+# Test: Pessimistic locking edge cases from GitHub issue
+#
+# Covers:
+#   1. Non-existing rows can be locked by SELECT FOR UPDATE
+#   2. DELETE and UPDATE acquire locks (not just SELECT FOR UPDATE)
+#   3. INSERT respects locks held on the same PK
+#   4. INSERT on a non-existing locked key blocks correctly
+#   5. Concurrent INSERTs on different keys do not block
+#
+
+call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+
+--echo #
+--echo # Setup
+--echo #
+
+CREATE TABLE t (
+  i INT,
+  PRIMARY KEY (i)
+) ENGINE=TidesDB;
+
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+
+connect (conA, localhost, root,,);
+connect (conB, localhost, root,,);
+
+--echo #
+--echo # TEST 1: SELECT FOR UPDATE on non-existing row blocks DELETE
+--echo #   Connection A locks i=15 (does not exist).
+--echo #   Connection B deletes i=2 (succeeds immediately),
+--echo #   then tries to delete i=15 (must block).
+--echo #
+
+connection conA;
+BEGIN;
+SELECT * FROM t WHERE i = 15 FOR UPDATE;
+
+connection conB;
+DELETE FROM t WHERE i = 2;
+--send DELETE FROM t WHERE i = 15
+
+connection conA;
+--sleep 0.5
+COMMIT;
+
+connection conB;
+--reap
+
+connection default;
+--echo # i=2 and i=15 both deleted (i=15 was no-op but lock was respected)
+SELECT * FROM t ORDER BY i;
+
+--echo #
+--echo # TEST 2: DELETE acquires a lock that blocks another DELETE
+--echo #   Connection A deletes i=3 inside a transaction.
+--echo #   Connection B deletes i=4 (succeeds immediately),
+--echo #   then tries to delete i=3 (must block until A commits).
+--echo #
+
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+
+connection conA;
+BEGIN;
+DELETE FROM t WHERE i = 3;
+
+connection conB;
+DELETE FROM t WHERE i = 4;
+--send DELETE FROM t WHERE i = 3
+
+connection conA;
+--sleep 0.5
+COMMIT;
+
+connection conB;
+--reap
+
+connection default;
+--echo # i=3 and i=4 both deleted
+SELECT * FROM t ORDER BY i;
+
+--echo #
+--echo # TEST 3: UPDATE acquires a lock that blocks another UPDATE
+--echo #
+
+DROP TABLE t;
+CREATE TABLE t (i INT, v INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
+
+connection conA;
+BEGIN;
+UPDATE t SET v = 99 WHERE i = 3;
+
+connection conB;
+UPDATE t SET v = 88 WHERE i = 2;
+--send UPDATE t SET v = 77 WHERE i = 3
+
+connection conA;
+--sleep 0.5
+COMMIT;
+
+connection conB;
+--reap
+
+connection default;
+--echo # conA set v=99, then conB overwrote with v=77
+SELECT * FROM t ORDER BY i;
+
+--echo #
+--echo # TEST 4: INSERT blocked by SELECT FOR UPDATE on non-existing key
+--echo #   This is the critical fix -- previously INSERT bypassed the lock.
+--echo #   Connection A does SELECT FOR UPDATE on i=15 (non-existing).
+--echo #   Connection B tries INSERT i=15 (must block until A commits).
+--echo #
+
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+
+connection conA;
+BEGIN;
+SELECT * FROM t WHERE i = 15 FOR UPDATE;
+
+connection conB;
+--send INSERT INTO t VALUES (15)
+
+connection conA;
+--sleep 0.5
+COMMIT;
+
+connection conB;
+--reap
+
+connection default;
+--echo # i=15 now exists (inserted by conB after conA released the lock)
+SELECT * FROM t WHERE i >= 10 ORDER BY i;
+
+--echo #
+--echo # TEST 5: INSERT blocked by DELETE on existing row
+--echo #   Connection A deletes i=3 inside a transaction.
+--echo #   Connection B tries to INSERT i=3 (must block).
+--echo #
+
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+
+connection conA;
+BEGIN;
+DELETE FROM t WHERE i = 3;
+
+connection conB;
+--send INSERT INTO t VALUES (3)
+
+connection conA;
+--sleep 0.5
+COMMIT;
+
+connection conB;
+--reap
+
+connection default;
+--echo # i=3 was deleted by conA, then re-inserted by conB
+SELECT * FROM t ORDER BY i;
+
+--echo #
+--echo # TEST 6: Concurrent INSERTs on different keys do not block
+--echo #
+
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+
+connection conA;
+BEGIN;
+INSERT INTO t VALUES (100);
+
+connection conB;
+INSERT INTO t VALUES (200);
+
+connection conA;
+COMMIT;
+
+connection default;
+--echo # Both inserts succeeded without blocking
+SELECT * FROM t ORDER BY i;
+
+--echo #
+--echo # TEST 7: Autocommit UPDATE blocked by SELECT FOR UPDATE
+--echo #
+
+DROP TABLE t;
+CREATE TABLE t (i INT, PRIMARY KEY (i)) ENGINE=TidesDB;
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+
+connection conA;
+BEGIN;
+SELECT * FROM t WHERE i = 3 FOR UPDATE;
+
+connection conB;
+--send UPDATE t SET i = 33 WHERE i = 3
+
+connection conA;
+--sleep 0.5
+COMMIT;
+
+connection conB;
+--reap
+
+connection default;
+--echo # conA released lock, then conB's autocommit UPDATE renamed i=3 to i=33
+SELECT * FROM t ORDER BY i;
+
+--echo #
+--echo # Cleanup
+--echo #
+
+disconnect conA;
+disconnect conB;
+connection default;
+
+DROP TABLE t;
+
+--source suite/tidesdb/include/cleanup_tidesdb.inc
+--echo # Done.

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -129,7 +129,9 @@ static handlerton *tidesdb_hton;
 */
 
 /* Number of hash partitions for the row lock table.
-   Configured via tidesdb_row_lock_stripes sysvar (default 1024). */
+   65536 partitions (~512 KB overhead) virtually eliminates false contention
+   between unrelated rows while keeping memory usage negligible. */
+static constexpr ulong ROW_LOCK_PARTITIONS = 65536;
 
 /* Row lock entry in the hash table */
 struct tdb_row_lock_t
@@ -153,12 +155,11 @@ struct tdb_lock_partition_t
 };
 
 static tdb_lock_partition_t *lock_partitions = NULL;
-static ulong srv_row_lock_stripes = 1024;
 
 static inline uint tdb_lock_part(const uchar *key, uint len)
 {
     uint64_t h = XXH3_64bits(key, len);
-    return (uint)(h % srv_row_lock_stripes);
+    return (uint)(h % ROW_LOCK_PARTITIONS);
 }
 
 /* Find or create a lock entry in the partition's hash chain.
@@ -470,22 +471,19 @@ static MYSQL_SYSVAR_BOOL(print_all_conflicts, srv_print_all_conflicts, PLUGIN_VA
                          NULL, NULL, 0);
 
 static MYSQL_SYSVAR_BOOL(pessimistic_locking, srv_pessimistic_locking, PLUGIN_VAR_RQCMDARG,
-                         "Enable plugin-level row locks for UPDATE/DELETE. "
+                         "Enable plugin-level row locks for SELECT ... FOR UPDATE, "
+                         "UPDATE, DELETE, and INSERT on user-defined primary keys. "
                          "OFF (default): pure optimistic MVCC -- concurrent writers on the "
                          "same row are detected at COMMIT time (TDB_ERR_CONFLICT). "
-                         "ON: writers acquire a striped mutex per PK hash, serializing "
-                         "concurrent access to the same row like InnoDB's row locks. "
-                         "Enable for TPC-C or legacy workloads that depend on "
-                         "SELECT ... FOR UPDATE semantics",
+                         "ON: all write-intent statements acquire per-row locks via a "
+                         "partitioned hash-table lock manager with wait-for-graph "
+                         "deadlock detection. Locks are held until COMMIT or ROLLBACK. "
+                         "Both explicit transactions and autocommit statements participate. "
+                         "Locks can be acquired on non-existing PK values (e.g. SELECT "
+                         "... FOR UPDATE on a missing row blocks INSERT of that key). "
+                         "Enable for TPC-C or workloads that depend on row-level "
+                         "serialization semantics",
                          NULL, NULL, 0);
-
-static MYSQL_SYSVAR_ULONG(row_lock_stripes, srv_row_lock_stripes,
-                          PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-                          "Number of striped mutexes for pessimistic row locking. "
-                          "Higher values reduce false contention between unrelated rows "
-                          "at the cost of memory. Only meaningful when "
-                          "tidesdb_pessimistic_locking=ON",
-                          NULL, NULL, 1024, 64, 65536, 0);
 
 static MYSQL_SYSVAR_ULONGLONG(block_cache_size, srv_block_cache_size,
                               PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
@@ -747,7 +745,7 @@ static MYSQL_SYSVAR_STR(backup_dir, srv_backup_dir, PLUGIN_VAR_RQCMDARG | PLUGIN
                         "Example: SET GLOBAL tidesdb_backup_dir = '/path/to/backup'",
                         NULL, tidesdb_backup_dir_update, NULL);
 
-/* ---- Checkpoint (hard-link snapshot) via system variable ---- */
+/* Checkpoint (hard-link snapshot) via system variable */
 
 static char *srv_checkpoint_dir = NULL;
 
@@ -803,7 +801,6 @@ static struct st_mysql_sys_var *tidesdb_system_variables[] = {
     MYSQL_SYSVAR(checkpoint_dir),
     MYSQL_SYSVAR(print_all_conflicts),
     MYSQL_SYSVAR(pessimistic_locking),
-    MYSQL_SYSVAR(row_lock_stripes),
     MYSQL_SYSVAR(data_home_dir),
     MYSQL_SYSVAR(ttl),
     MYSQL_SYSVAR(skip_unique_check),
@@ -962,7 +959,7 @@ static inline bool is_data_key(const uint8_t *key, size_t key_size)
     return key_size > 0 && key[0] == KEY_NS_DATA;
 }
 
-/* ----- Shared enum-to-constant maps (used by create, open, prepare_inplace) ----- */
+/* Shared enum-to-constant maps (used by create, open, prepare_inplace) */
 
 static const int tdb_compression_map[] = {TDB_COMPRESS_NONE, TDB_COMPRESS_SNAPPY, TDB_COMPRESS_LZ4,
                                           TDB_COMPRESS_ZSTD, TDB_COMPRESS_LZ4_FAST};
@@ -1557,11 +1554,10 @@ static int tidesdb_init_func(void *p)
     /* Initialize partitioned lock table for pessimistic row locking.
        Partition count comes from tidesdb_row_lock_stripes sysvar. */
     lock_partitions = (tdb_lock_partition_t *)my_malloc(
-        PSI_NOT_INSTRUMENTED, srv_row_lock_stripes * sizeof(tdb_lock_partition_t),
-        MYF(MY_ZEROFILL));
+        PSI_NOT_INSTRUMENTED, ROW_LOCK_PARTITIONS * sizeof(tdb_lock_partition_t), MYF(MY_ZEROFILL));
     if (lock_partitions)
     {
-        for (ulong i = 0; i < srv_row_lock_stripes; i++)
+        for (ulong i = 0; i < ROW_LOCK_PARTITIONS; i++)
         {
             mysql_mutex_init(0, &lock_partitions[i].mutex, MY_MUTEX_INIT_FAST);
             lock_partitions[i].chain = NULL;
@@ -1682,7 +1678,7 @@ static int tidesdb_deinit_func(void *p)
     mysql_mutex_destroy(&last_conflict_mutex);
     if (lock_partitions)
     {
-        for (ulong i = 0; i < srv_row_lock_stripes; i++)
+        for (ulong i = 0; i < ROW_LOCK_PARTITIONS; i++)
         {
             /* Free all lock entries in the hash chain */
             tdb_row_lock_t *e = lock_partitions[i].chain;
@@ -3034,6 +3030,22 @@ int ha_tidesdb::write_row(const uchar *buf)
         trx->stmt_was_dirty = true;
     }
 
+    /* Acquire pessimistic row lock for INSERT when pessimistic_locking=ON.
+       Without this, INSERT bypasses locks held by SELECT ... FOR UPDATE,
+       UPDATE, and DELETE on the same PK -- breaking the serialization
+       guarantee that pessimistic locking is supposed to provide.
+       We use the comparable PK bytes (pk, pk_len) which are the same key
+       format used by index_read_map() for lock acquisition. */
+    if (unlikely(srv_pessimistic_locking) && share->has_user_pk && trx)
+    {
+        int lrc = row_lock_acquire(trx, pk, pk_len);
+        if (lrc)
+        {
+            tmp_restore_column_map(&table->read_set, old_map);
+            DBUG_RETURN(lrc);
+        }
+    }
+
     /* Cache THDVAR lookups once per statement. */
     if (!cached_thdvars_valid_)
     {
@@ -3982,10 +3994,10 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
     uint old_pk_len = current_pk_len_;
     memcpy(old_pk, current_pk_buf_, old_pk_len);
 
-    /* Row locks are acquired in index_read_map() for SELECT ... FOR UPDATE.
-       No need to acquire here - the row is already locked from the preceding
-       locking read.  For plain UPDATE without FOR UPDATE, the operation is
-       atomic (single autocommit statement) and no lock is needed. */
+    /* Row locks are acquired in index_read_map() during the preceding
+       locking read (SELECT ... FOR UPDATE, UPDATE, DELETE all go through
+       index_read_map with write intent).  No need to acquire here - the
+       row is already locked. */
 
     /* new_pk uses its own stack buffer so it survives the current_pk_buf_
        manipulations in the secondary index loop (avoids overlapping memcpy UB) */
@@ -4110,8 +4122,8 @@ int ha_tidesdb::delete_row(const uchar *buf)
     /* Use cached_trx_ from external_lock to avoid per-row hash lookups. */
     tidesdb_trx_t *trx = cached_trx_;
 
-    /* Row locks are acquired in index_read_map() for SELECT ... FOR UPDATE.
-       No need to acquire here - see update_row() comment. */
+    /* Row locks are acquired in index_read_map() during the preceding
+       locking read - see update_row() comment. */
 
     {
         int erc = ensure_stmt_txn();
@@ -5807,8 +5819,8 @@ maria_declare_plugin(tidesdb){
     PLUGIN_LICENSE_GPL,
     tidesdb_init_func,
     tidesdb_deinit_func,
-    0x40100,
+    0x40101,
     NULL,
     tidesdb_system_variables,
-    "4.1.0",
+    "4.1.1",
     MariaDB_PLUGIN_MATURITY_GAMMA} maria_declare_plugin_end;

--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -33,51 +33,51 @@ extern "C"
 #include <tidesdb/db.h>
 }
 
-/* ----- Key namespace prefixes (first byte of every TidesDB key) ------------------------------- */
+/* Key namespace prefixes (first byte of every TidesDB key) */
 static constexpr uint8_t KEY_NS_META = 0x00;
 static constexpr uint8_t KEY_NS_DATA = 0x01;
 
-/* ----- CF naming ------------------------------------------------------------------------------ */
+/* CF naming */
 static constexpr const char CF_INDEX_INFIX[] = "__idx_";
 
-/* ----- Hidden primary key size (tables without explicit PK) ----------------------------------- */
+/* Hidden primary key size (tables without explicit PK) */
 static constexpr size_t HIDDEN_PK_SIZE = sizeof(uint64_t);
 
-/* ----- Maximum number of secondary indexes we support ----------------------------------------- */
+/* Maximum number of secondary indexes we support */
 static constexpr uint MAX_TIDESDB_KEYS = MAX_KEY;
 
-/* ----- Cost model constants for the optimizer ------------------------------------------------- */
+/* Cost model constants for the optimizer */
 static constexpr double TIDESDB_COST_SEQ_READ = 0.00005;
 static constexpr double TIDESDB_COST_KEY_READ = 0.00003;
 static constexpr double TIDESDB_COST_RANGE_SETUP = 0.0001;
 static constexpr double TIDESDB_DEFAULT_READ_AMP = 1.0;
 
-/* ----- Stats cache refresh interval (microseconds) -------------------------------------------- */
+/* Stats cache refresh interval (microseconds) */
 static constexpr long long TIDESDB_STATS_REFRESH_US = 2000000LL; /* 2 seconds */
 
-/* ----- Minimum stats.records to avoid optimizer edge cases with 0 rows ------------------------ */
+/* Minimum stats.records to avoid optimizer edge cases with 0 rows */
 static constexpr ha_rows TIDESDB_MIN_STATS_RECORDS = 2;
 
-/* ----- Inplace index build batch commit size -------------------------------------------------- */
+/* Inplace index build batch commit size */
 static constexpr ha_rows TIDESDB_INDEX_BUILD_BATCH = 10000;
 
-/* ----- Bulk insert mid-txn commit threshold (ops, not rows) ----------------------------------- */
+/* Bulk insert mid-txn commit threshold (ops, not rows) */
 static constexpr ha_rows TIDESDB_BULK_INSERT_BATCH_OPS = 50000;
 
-/* ----- Encryption ----------------------------------------------------------------------------- */
+/* Encryption */
 static constexpr uint TIDESDB_ENC_IV_LEN = 16;
 static constexpr uint TIDESDB_ENC_KEY_LEN = 32;
 
-/* ----- Bloom filter FPR conversion (table option stores parts per 10000) ---------------------- */
+/* Bloom filter FPR conversion (table option stores parts per 10000) */
 static constexpr double TIDESDB_BLOOM_FPR_DIVISOR = 10000.0;
 
-/* ----- Skip list probability conversion (table option stores percentage) ---------------------- */
+/* Skip list probability conversion (table option stores percentage) */
 static constexpr float TIDESDB_SKIP_LIST_PROB_DIV = 100.0f;
 
-/* ----- TTL sentinel value meaning no expiration ----------------------------------------------- */
+/* TTL sentinel value meaning no expiration */
 static constexpr time_t TIDESDB_TTL_NONE = (time_t)-1;
 
-/* ----- Default block cache size (bytes) ------------------------------------------------------- */
+/* Default block cache size (bytes) */
 static constexpr ulonglong TIDESDB_DEFAULT_BLOCK_CACHE = 256ULL * 1024 * 1024; /* 256M */
 
 /*
@@ -292,7 +292,7 @@ class ha_tidesdb : public handler
     bool keyread_only_;
     bool write_can_replace_; /* true during REPLACE INTO (HA_EXTRA_WRITE_CAN_REPLACE) */
 
-    /* ----- private helpers ----------------------------------------------------------------------
+    /* private helpers
      */
     int ensure_stmt_txn(); /* lazy txn creation on first data access */
     TidesDB_share *get_share();


### PR DESCRIPTION
issue #101 when pessimistic locking is enabled, insert statements were not
acquiring or checking row locks, which meant they could bypass locks held by
select for update, update, and delete on the same primary key. this broke the
serialization guarantee that pessimistic locking is supposed to provide -- for
example, a select for update on a non-existing row (a standard 'reserve this
key' pattern) would not block a concurrent insert of that same key. the fix
adds a row_lock_acquire() call in write_row() for tables with user-defined
primary keys when tidesdb_pessimistic_locking=on, using the same comparable pk
bytes that index_read_map() uses, so insert now participates in the same lock
manager as all other write-intent statements. the sysvar description in
the source code and read me was also corrected to accurately
reflect that all write-intent statements (select for update, update, delete,
and now insert) acquire locks, that autocommit statements participate in
locking, and that locks can be acquired on non-existing pk values. stale
comments in update_row() and delete_row() were updated to no longer claim
locks are only for select for update. the plugin version was bumped from
4.1.0 to 4.1.1. also addition of new tidesdb_pessimistic_insert_lock.mtr
mtr test; removed old row_lock_stripes, we use row lock partitions, also 
partition size increased to 65536