### PR TITLE
Docker configuration fixes

### DIFF
--- a/docker/conf/my.cnf
+++ b/docker/conf/my.cnf
@@ -94,9 +94,13 @@ plugin_load_add   = simple_password_check
 !include /etc/mysql/inc/tidesdb.cfg
 
 [client]
+# Used by all clients
 port                  = 3306
 socket                = /tmp/mariadb.sock
-default-character-set = utf8mb4
+
+[mariadb-client]
+# Used by mariadb client
+default_character_set = utf8mb4
 
 [mysqldump]
 single_transaction

--- a/docker/conf/my.cnf
+++ b/docker/conf/my.cnf
@@ -46,7 +46,6 @@ default_storage_engine        = InnoDB
 innodb_buffer_pool_size       = 128M
 innodb_log_file_size          = 48M
 innodb_flush_log_at_trx_commit = 1
-innodb_file_per_table         = ON
 innodb_rollback_on_timeout    = 1
 
 # Other Storage Engines


### PR DESCRIPTION
Fixes in the configuration file:

- Remove deprecated `innodb_file_per_table`
- Split `[client]` and `[mariadb-client]` because `default_character_set` is not understood by some clients
- Use `default_character_set` with underscore instead of dashes for consistence
