### PR TITLE
TideSQL 4 PATCH (v4.2.5)

### DIFF
--- a/README
+++ b/README
@@ -24,6 +24,27 @@ To skip storage engines you don't need (saves build time and reduces warnings):
 ./install.sh --list-engines                       # see what can be skipped
 ./install.sh --skip-engines mroonga,rocksdb,connect,spider,oqgraph,columnstore
 
+To link libtidesdb against a non-default allocator (jemalloc is a common
+pick for write-heavy workloads):
+
+./install.sh --allocator jemalloc
+./install.sh --allocator mimalloc
+./install.sh --allocator tcmalloc
+
+The flag only affects libtidesdb.so's internal allocations; mariadbd's
+allocator is unchanged.  For a process-wide swap also LD_PRELOAD the
+allocator at mariadbd startup:
+
+  LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+    /usr/local/mariadb/bin/mariadbd-safe \
+    --defaults-file=/usr/local/mariadb/my.cnf &
+
+Note that --rebuild-plugin does NOT rebuild libtidesdb, so changing the
+allocator requires a full install run (omit --rebuild-plugin) to take
+effect.  Verify the linkage with:
+
+  ldd /usr/local/lib/libtidesdb.so | grep -E 'jemalloc|mimalloc|tcmalloc'
+
 Skippable engines:
   archive        Archive storage engine (read-only row-format tables)
   blackhole      Blackhole engine (accepts writes, stores nothing)
@@ -221,8 +242,17 @@ Core:
 - Block cache for frequently accessed data
 - Primary key (single and composite) and secondary index support
 - Index Condition Pushdown (ICP) for secondary index scans
+- Multi-Range Read (MRR) with sorted point-lookup batching for queries of
+  the shape WHERE col IN (v1, v2, ..., vN).  Accepted only when every
+  range is a full-key point equality and there are 2+ ranges; keys are
+  sorted by comparable bytes so the LSM sees a monotone stream of seeks.
+- Bulk UPDATE / DELETE batching: multi-row UPDATE and DELETE statements
+  share the same mid-txn commit plumbing as bulk INSERT, keeping long
+  statements under TDB_MAX_TXN_OPS without ballooning txn memory
 - REPLACE INTO and INSERT ... ON DUPLICATE KEY UPDATE
-- AUTO_INCREMENT with O(1) atomic counter (no iterator per INSERT)
+- AUTO_INCREMENT with O(1) atomic counter (no iterator per INSERT).
+  TRUNCATE TABLE and ALTER TABLE ... AUTO_INCREMENT=N both correctly
+  reset the counter via the reset_auto_increment handler hook.
 - TTL (time-to-live) per-row and per-table expiration
 - Virtual/generated columns
 - Online backup (SET GLOBAL tidesdb_backup_dir = '/path')
@@ -235,6 +265,14 @@ Core:
 - SHOW ENGINE TIDESDB STATUS (DB stats, memory, cache, conflict info)
 - SHOW GLOBAL STATUS LIKE 'tidesdb%' (21 machine-readable status variables
   for monitoring tools: Prometheus, PMM, Datadog, etc.)
+- Handlerton lifecycle + administrative hooks wired:
+    drop_database    DROP DATABASE removes all TidesDB CFs for the db
+    flush_logs       FLUSH LOGS syncs the TidesDB WAL (safe before backup)
+    panic            orderly close on signal-driven shutdown
+    pre_shutdown     background thread quiesce before deinit
+    kill_query       KILL QUERY wakes waiters in row_lock_acquire and is
+                     checked inside rnd_next / index_next / spatial /
+                     ft_read so long scans return HA_ERR_ABORTED_BY_USER
 - Partitioning (RANGE, LIST, HASH, KEY)
 - Data-at-rest encryption (MariaDB encryption plugin integration)
 - Online DDL (instant metadata, inplace add/drop index, copy for columns)
@@ -419,7 +457,7 @@ Run specific test:
 
   perl mtr --suite=tidesdb tidesdb_crud
 
-Available tests (48 total, 280+ cases):
+Available tests (49 total, 280+ cases):
   tidesdb_alter_crash         Crash safety during ALTER TABLE operations
   tidesdb_analyze             ANALYZE TABLE with CF statistics output
   tidesdb_auto_increment      AUTO_INCREMENT edge cases (gaps, rollback, explicit values)
@@ -447,6 +485,7 @@ Available tests (48 total, 280+ cases):
   tidesdb_large_blob          Large BLOB/TEXT values (> 64KB, klog_value_threshold)
   tidesdb_load_data           Bulk insert path (multi-row INSERT, INSERT...SELECT)
   tidesdb_mixed_engine        Mixed-engine transactions (TidesDB + InnoDB in same txn)
+  tidesdb_mrr                 Multi-Range Read for WHERE col IN (...) on PK and secondary index
   tidesdb_object_store        Object store integration (CRUD, indexes, txns, bulk, compaction)
   tidesdb_online_ddl          Online DDL (instant, inplace, copy)
   tidesdb_options             Table and field options

--- a/docker/README.md
+++ b/docker/README.md
@@ -85,6 +85,11 @@ Some of them currently cannot be changed by using the scripts.
   WITH_TESTS        Include MTR in the image. 1=yes, 0=no. Default: 0
   WITH_S3           Build with S3 object store support. 1=yes, 0=no. Default: 0
                     Requires libcurl and OpenSSL (already in the base image).
+  ALLOCATOR         Memory allocator to link libtidesdb.so against.
+                    One of: system (default), jemalloc, mimalloc, tcmalloc.
+                    Only affects TidesDB's internal allocations; mariadbd's
+                    allocator is unchanged.  Combine with LD_PRELOAD at
+                    container startup for a process-wide swap.
   DISABLED_ENGINES  Normally set indirectly via EXCLUDE_ENGINES /
                     INCLUDE_ENGINES in rebuild.sh (see REBUILD SCRIPT above).
 ```
@@ -116,6 +121,30 @@ Example - build with S3 object store support:
       --build-arg WITH_S3=1 \
       -t tidesql:11.8.6-s3 \
       .
+```
+
+Example - link libtidesdb against jemalloc:
+
+```
+  docker build \
+      -f docker/ubuntu/Dockerfile \
+      --build-arg MARIADB_VERSION=11.8.6 \
+      --build-arg TIDESDB_VERSION=v9.0.0 \
+      --build-arg ALLOCATOR=jemalloc \
+      -t tidesql:11.8.6-jemalloc \
+      .
+
+  # Or via setup.sh / rebuild.sh:
+  ALLOCATOR=jemalloc bash docker/rebuild.sh
+```
+
+For a process-wide allocator swap (covers mariadbd too), start the
+container with an LD_PRELOAD pointing at the same library:
+
+```
+  docker run -d --name tidesql \
+      -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+      -p 3306:3306 tidesql:11.8.6-jemalloc
 ```
 
 

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -98,10 +98,20 @@ if [ -z "${TIDESDB_VERSION:-}" ]; then
     TIDESDB_VERSION="$_tidesdb_latest"
 fi
 
+# Memory allocator for libtidesdb.so.  One of: system (default), jemalloc, mimalloc, tcmalloc.
+# Forwarded to the Dockerfile as --build-arg ALLOCATOR=...  Affects only TidesDB's
+# internal allocations; for a process-wide swap also LD_PRELOAD at container startup.
+ALLOCATOR=${ALLOCATOR:-system}
+case "${ALLOCATOR}" in
+    system|jemalloc|mimalloc|tcmalloc) ;;
+    *) echo "Error: ALLOCATOR must be one of system|jemalloc|mimalloc|tcmalloc (got '${ALLOCATOR}')" >&2; exit 1 ;;
+esac
+
 echo "### 2. Building the new image..."
 BUILD_ARGS=(
     --build-arg "MARIADB_VERSION=${MARIADB_VERSION}"
     --build-arg "TIDESDB_VERSION=${TIDESDB_VERSION}"
+    --build-arg "ALLOCATOR=${ALLOCATOR}"
 )
 [ -n "$DISABLED_ENGINES" ] && BUILD_ARGS+=(--build-arg "DISABLED_ENGINES=${DISABLED_ENGINES}")
 docker build \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -13,6 +13,10 @@ ARG WITH_TESTS=0
 ARG DISABLED_ENGINES=""
 # Set WITH_S3=1 to build with S3-compatible object store support (requires libcurl + OpenSSL).
 ARG WITH_S3=0
+# Memory allocator for libtidesdb.so: system (default), jemalloc, mimalloc, or tcmalloc.
+# Affects only TidesDB's internal allocations; mariadbd's allocator is unchanged.
+# Combine with LD_PRELOAD at container startup for a process-wide swap.
+ARG ALLOCATOR=system
 
 # Persist key paths as environment variables so they are available in every
 # RUN step and at container runtime.
@@ -21,14 +25,22 @@ ENV TIDESDB_PREFIX=${TIDESDB_PREFIX} \
     DEBIAN_FRONTEND=noninteractive
 ENV PATH="${MARIADB_PREFIX}/bin:${PATH}"
 
-# 1. Install system dependencies 
+# 1. Install system dependencies
 RUN apt-get update -qq && \
+    case "${ALLOCATOR}" in \
+        jemalloc) ALLOC_PKG=libjemalloc-dev ;; \
+        mimalloc) ALLOC_PKG=libmimalloc-dev ;; \
+        tcmalloc) ALLOC_PKG=libgoogle-perftools-dev ;; \
+        system|'') ALLOC_PKG= ;; \
+        *) echo "ERROR: ALLOCATOR must be one of system|jemalloc|mimalloc|tcmalloc (got '${ALLOCATOR}')"; exit 1 ;; \
+    esac && \
     apt-get install -y -qq \
         build-essential cmake ninja-build bison flex \
         libzstd-dev liblz4-dev libsnappy-dev \
         libncurses-dev libssl-dev libxml2-dev \
         libevent-dev libcurl4-openssl-dev \
-        pkg-config git gnutls-dev && \
+        pkg-config git gnutls-dev \
+        ${ALLOC_PKG} && \
     rm -rf /var/lib/apt/lists/*
 
 # 2. Copy TidesDB storage engine plugin and test suite from this repo 
@@ -38,14 +50,21 @@ COPY mysql-test/suite/tidesdb       /opt/tidesql/mysql-test/suite/tidesdb
 
 # 3. Build and install TidesDB library
 ARG WITH_S3=0
+ARG ALLOCATOR=system
 RUN TIDESDB_VER="${TIDESDB_VERSION}" && \
     if [ -z "$TIDESDB_VER" ]; then \
         TIDESDB_VER=$(curl -sf https://api.github.com/repos/tidesdb/tidesdb/releases/latest \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4) || true; \
     fi && \
     if [ -z "$TIDESDB_VER" ]; then echo "ERROR: could not resolve TidesDB version"; exit 1; fi && \
-    echo "Building TidesDB version: $TIDESDB_VER" && \
+    echo "Building TidesDB version: $TIDESDB_VER with allocator=${ALLOCATOR}" && \
     S3_FLAG=$([ "${WITH_S3}" = "1" ] && echo "-DTIDESDB_WITH_S3=ON" || true) && \
+    case "${ALLOCATOR}" in \
+        jemalloc) ALLOC_FLAG="-DTIDESDB_WITH_JEMALLOC=ON" ;; \
+        mimalloc) ALLOC_FLAG="-DTIDESDB_WITH_MIMALLOC=ON" ;; \
+        tcmalloc) ALLOC_FLAG="-DTIDESDB_WITH_TCMALLOC=ON" ;; \
+        *)        ALLOC_FLAG="" ;; \
+    esac && \
     git clone --depth 1 --branch "$TIDESDB_VER" \
         https://github.com/tidesdb/tidesdb.git /tmp/tidesql-build/tidesdb-lib && \
     cmake \
@@ -55,11 +74,20 @@ RUN TIDESDB_VER="${TIDESDB_VERSION}" && \
         -DCMAKE_INSTALL_PREFIX="${TIDESDB_PREFIX}" \
         -DTIDESDB_BUILD_TESTS=OFF \
         -DBUILD_SHARED_LIBS=ON \
-        ${S3_FLAG} && \
+        ${S3_FLAG} \
+        ${ALLOC_FLAG} && \
     cmake --build /tmp/tidesql-build/tidesdb-lib/build \
         --config Release --parallel "$(nproc)" && \
     cmake --install /tmp/tidesql-build/tidesdb-lib/build --config Release && \
     ldconfig && \
+    if [ "${ALLOCATOR}" != "system" ]; then \
+        LINKED=$(ldd "${TIDESDB_PREFIX}/lib/libtidesdb.so" 2>/dev/null | grep -Eo '(jemalloc|mimalloc|tcmalloc)[^ ]*' | head -1 || true); \
+        if [ -n "$LINKED" ]; then \
+            echo "[OK] libtidesdb linked against ${LINKED}"; \
+        else \
+            echo "[WARNING] ALLOCATOR=${ALLOCATOR} requested but no allocator library appears in ldd output"; \
+        fi; \
+    fi && \
     rm -rf /tmp/tidesql-build/tidesdb-lib
 
 # 4. Clone MariaDB source and inject TidesDB storage engine plugin

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,11 @@
 #   --rebuild-plugin             Rebuild only the TidesDB plugin (fast dev cycle)
 #   --pgo                       Enable Profile-Guided Optimization (3-phase build)
 #   --s3                        Build TidesDB with S3 object store connector (requires libcurl + OpenSSL)
+#   --allocator  NAME           Memory allocator for libtidesdb.so: system (default), jemalloc, mimalloc, or tcmalloc.
+#                               Only affects TidesDB's internal allocations; mariadbd's allocator is unchanged.
+#                               For a process-wide swap also LD_PRELOAD the allocator at mariadbd startup.
+#                               Note: --rebuild-plugin does NOT rebuild libtidesdb, so changing this flag
+#                               requires a full install run (omit --rebuild-plugin) to take effect.
 #   --help                      Show this help message
 #
 # Platform defaults:
@@ -169,6 +174,15 @@ REBUILD_PLUGIN=false
 PGO_ENABLED=false
 SKIP_ENGINES=""
 WITH_S3=false
+# Memory allocator to build libtidesdb against.  One of:
+#   system     glibc / platform default (no extra dep)
+#   jemalloc   routes TidesDB allocations through jemalloc (pkg: libjemalloc-dev)
+#   mimalloc   routes TidesDB allocations through mimalloc (pkg: libmimalloc-dev)
+#   tcmalloc   routes TidesDB allocations through tcmalloc (pkg: libgoogle-perftools-dev)
+# Note this affects only libtidesdb.so's internal allocations; mariadbd's own
+# allocator is unchanged.  For a process-wide swap, combine with
+# LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 at mariadbd startup.
+ALLOCATOR="system"
 
 # ── Ensure VCPKG_ROOT is set on Windows (needed even with --skip-deps) ────────
 if [[ "$OS" == "windows" ]]; then
@@ -249,6 +263,13 @@ while [[ $# -gt 0 ]]; do
         --list-engines)     list_engines ;;
         --pgo)              PGO_ENABLED=true;       shift   ;;
         --s3)               WITH_S3=true;           shift   ;;
+        --allocator)
+            ALLOCATOR="$2"
+            case "$ALLOCATOR" in
+                system|jemalloc|mimalloc|tcmalloc) ;;
+                *) die "--allocator must be one of system|jemalloc|mimalloc|tcmalloc (got '$ALLOCATOR')" ;;
+            esac
+            shift 2 ;;
         --help|-h)          usage ;;
         *) die "Unknown option: $1 (try --help)" ;;
     esac
@@ -318,6 +339,7 @@ _cfg_lines=(
     "Parallel jobs    : ${GREEN}${JOBS}${NC}"
     "Detected OS      : ${GREEN}${OS}${NC}"
     "PGO build        : ${GREEN}${PGO_ENABLED}${NC}"
+    "Allocator        : ${GREEN}${ALLOCATOR}${NC}"
 )
 if [[ -n "$SKIP_ENGINES" ]]; then
     _cfg_lines+=("Skip engines     : ${YELLOW}${SKIP_ENGINES}${NC}")
@@ -366,6 +388,24 @@ install_deps() {
 
     info "Installing system dependencies for ${OS}..."
 
+    # Per-OS package name for the selected allocator (empty for 'system').
+    local allocator_pkg=""
+    case "$OS:$ALLOCATOR" in
+        debian:jemalloc)  allocator_pkg="libjemalloc-dev" ;;
+        debian:mimalloc)  allocator_pkg="libmimalloc-dev" ;;
+        debian:tcmalloc)  allocator_pkg="libgoogle-perftools-dev" ;;
+        redhat:jemalloc)  allocator_pkg="jemalloc-devel" ;;
+        redhat:mimalloc)  allocator_pkg="mimalloc-devel" ;;
+        redhat:tcmalloc)  allocator_pkg="gperftools-devel" ;;
+        arch:jemalloc)    allocator_pkg="jemalloc" ;;
+        arch:mimalloc)    allocator_pkg="mimalloc" ;;
+        arch:tcmalloc)    allocator_pkg="gperftools" ;;
+        macos:jemalloc)   allocator_pkg="jemalloc" ;;
+        macos:mimalloc)   allocator_pkg="mimalloc" ;;
+        macos:tcmalloc)   allocator_pkg="gperftools" ;;
+    esac
+    [[ -n "$allocator_pkg" ]] && info "Allocator ${ALLOCATOR} -> installing ${allocator_pkg}"
+
     case "$OS" in
         debian)
             sudo apt-get update -qq
@@ -374,7 +414,8 @@ install_deps() {
                 libzstd-dev liblz4-dev libsnappy-dev \
                 libncurses-dev libssl-dev libxml2-dev \
                 libevent-dev libcurl4-openssl-dev \
-                pkg-config git gnutls-dev
+                pkg-config git gnutls-dev \
+                ${allocator_pkg}
             ;;
         redhat)
             sudo dnf install -y \
@@ -382,7 +423,8 @@ install_deps() {
                 libzstd-devel lz4-devel snappy-devel \
                 ncurses-devel openssl-devel libxml2-devel \
                 libevent-devel libcurl-devel \
-                pkg-config git gnutls-devel
+                pkg-config git gnutls-devel \
+                ${allocator_pkg}
             ;;
         arch)
             sudo pacman -Sy --noconfirm --needed \
@@ -390,14 +432,16 @@ install_deps() {
                 zstd lz4 snappy \
                 ncurses openssl libxml2 \
                 libevent curl \
-                pkg-config git gnutls
+                pkg-config git gnutls \
+                ${allocator_pkg}
             ;;
         macos)
             if ! command -v brew &>/dev/null; then
                 die "Homebrew is required on macOS. Install from https://brew.sh"
             fi
             brew install cmake ninja bison flex \
-                snappy lz4 zstd openssl@3 gnutls
+                snappy lz4 zstd openssl@3 gnutls \
+                ${allocator_pkg}
             ;;
         windows)
             if [[ -z "${VCPKG_ROOT:-}" ]]; then
@@ -479,6 +523,21 @@ build_tidesdb() {
         info "S3 object store connector enabled"
     fi
 
+    case "$ALLOCATOR" in
+        jemalloc)
+            cmake_args+=(-DTIDESDB_WITH_JEMALLOC=ON)
+            info "Building libtidesdb with jemalloc"
+            ;;
+        mimalloc)
+            cmake_args+=(-DTIDESDB_WITH_MIMALLOC=ON)
+            info "Building libtidesdb with mimalloc"
+            ;;
+        tcmalloc)
+            cmake_args+=(-DTIDESDB_WITH_TCMALLOC=ON)
+            info "Building libtidesdb with tcmalloc"
+            ;;
+    esac
+
     case "$OS" in
         macos)
             local sdk_root
@@ -496,6 +555,22 @@ build_tidesdb() {
     cmake "${cmake_args[@]}"
     cmake --build "${tidesdb_src}/build" --config Release --parallel "${JOBS}"
     run_privileged_tidesdb cmake --install "${tidesdb_src}/build" --config Release
+
+    # Show which allocator is actually linked so users can verify after a build.
+    if [[ "$ALLOCATOR" != "system" ]]; then
+        local installed_lib
+        installed_lib="$(ls -1 "${TIDESDB_PREFIX}/lib/libtidesdb."{so,dylib} 2>/dev/null | head -1 || true)"
+        if [[ -n "$installed_lib" ]] && command -v ldd &>/dev/null; then
+            local allocator_linkage
+            allocator_linkage="$(ldd "$installed_lib" 2>/dev/null | grep -Eo '(jemalloc|mimalloc|tcmalloc)[^ ]*' | head -1 || true)"
+            if [[ -n "$allocator_linkage" ]]; then
+                ok "libtidesdb is linked against ${allocator_linkage}"
+            else
+                warn "Requested allocator ${ALLOCATOR} but none of libjemalloc/libmimalloc/libtcmalloc appears in \`ldd ${installed_lib}\`."
+                warn "  Check cmake output above for missing packages."
+            fi
+        fi
+    fi
 
     # Update shared library cache on Linux
     case "$OS" in
@@ -810,6 +885,18 @@ print_summary() {
     if $PGO_ENABLED; then
         _summary_lines+=("Build type           : ${CYAN}Release + PGO${NC}")
     fi
+    if [[ "$ALLOCATOR" != "system" ]]; then
+        _summary_lines+=(
+            "Allocator            : ${CYAN}${ALLOCATOR}${NC}"
+            ""
+            "Verify the allocator is linked into libtidesdb:"
+            "  ldd ${TIDESDB_PREFIX}/lib/libtidesdb.so | grep -E 'jemalloc|mimalloc|tcmalloc'"
+            ""
+            "For a process-wide allocator swap also LD_PRELOAD at startup:"
+            "  LD_PRELOAD=\$(pkg-config --variable=libdir ${ALLOCATOR})/lib${ALLOCATOR}.so.2 \\"
+            "    ${start_cmd} --defaults-file=${MARIADB_PREFIX}/${cnf_name} &"
+        )
+    fi
     _summary_lines+=(
         ""
         "Start MariaDB:"
@@ -1123,6 +1210,15 @@ main() {
 
     # Fast path: rebuild only the plugin and exit
     if $REBUILD_PLUGIN; then
+        # Allocator choice is baked into libtidesdb.so by build_tidesdb().  The
+        # rebuild-plugin path only recompiles ha_tidesdb.so against the already
+        # installed library, so --allocator has no effect here -- warn so users
+        # don't silently get a stale allocator.
+        if [[ "$ALLOCATOR" != "system" ]]; then
+            warn "--allocator=${ALLOCATOR} has no effect with --rebuild-plugin."
+            warn "  libtidesdb.so keeps its prior allocator linkage; to change"
+            warn "  allocators, re-run install.sh without --rebuild-plugin."
+        fi
         rebuild_plugin
         return
     fi

--- a/mysql-test/suite/tidesdb/r/tidesdb_analyze.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_analyze.result
@@ -13,15 +13,15 @@ INSERT INTO t1 VALUES (1, 'alpha'), (2, 'bravo'), (3, 'charlie'),
 ANALYZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	Engine-independent statistics collected
-test.t1	analyze	Note	TIDESDB: CF 'test__t1'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
-test.t1	analyze	Note	TIDESDB: avg_key=N bytes  avg_value=N bytes
-test.t1	analyze	Note	TIDESDB: level 1  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	TIDESDB: level 2  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	TIDESDB: level 3  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	TIDESDB: level 4  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	TIDESDB: level 5  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	TIDESDB: idx CF 'test__t1__idx_idx_val'  keys=N  data_size=N bytes  levels=5
-test.t1	analyze	Note	TIDESDB: idx 'idx_val' sampled=6 distinct=6 rec_per_key=1
+test.t1	analyze	Note	[TIDESDB] CF 'test__t1'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t1	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
+test.t1	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
+test.t1	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
+test.t1	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
+test.t1	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
+test.t1	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
+test.t1	analyze	Note	[TIDESDB] idx CF 'test__t1__idx_idx_val'  keys=N  data_size=N bytes  levels=5
+test.t1	analyze	Note	[TIDESDB] idx 'idx_val' sampled=6 distinct=6 rec_per_key=1
 test.t1	analyze	status	OK
 # ANALYZE a table without secondary indexes
 CREATE TABLE t2 (
@@ -32,13 +32,13 @@ INSERT INTO t2 VALUES (1, REPEAT('x', 100)), (2, REPEAT('y', 100));
 ANALYZE TABLE t2;
 Table	Op	Msg_type	Msg_text
 test.t2	analyze	status	Engine-independent statistics collected
-test.t2	analyze	Note	TIDESDB: CF 'test__t2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
-test.t2	analyze	Note	TIDESDB: avg_key=N bytes  avg_value=N bytes
-test.t2	analyze	Note	TIDESDB: level 1  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	TIDESDB: level 2  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	TIDESDB: level 3  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	TIDESDB: level 4  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	TIDESDB: level 5  sstables=N  size=N bytes  keys=N
+test.t2	analyze	Note	[TIDESDB] CF 'test__t2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t2	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
+test.t2	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
+test.t2	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
+test.t2	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
+test.t2	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
+test.t2	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
 test.t2	analyze	status	OK
 # ANALYZE an empty table
 CREATE TABLE t3 (
@@ -47,13 +47,13 @@ id INT PRIMARY KEY
 ANALYZE TABLE t3;
 Table	Op	Msg_type	Msg_text
 test.t3	analyze	status	Engine-independent statistics collected
-test.t3	analyze	Note	TIDESDB: CF 'test__t3'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
-test.t3	analyze	Note	TIDESDB: avg_key=N bytes  avg_value=N bytes
-test.t3	analyze	Note	TIDESDB: level 1  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	TIDESDB: level 2  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	TIDESDB: level 3  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	TIDESDB: level 4  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	TIDESDB: level 5  sstables=N  size=N bytes  keys=N
+test.t3	analyze	Note	[TIDESDB] CF 'test__t3'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t3	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
+test.t3	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
+test.t3	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
+test.t3	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
+test.t3	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
+test.t3	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
 test.t3	analyze	status	OK
 # Cleanup
 DROP TABLE t1, t2, t3;

--- a/mysql-test/suite/tidesdb/r/tidesdb_auto_increment.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_auto_increment.result
@@ -77,7 +77,20 @@ TRUNCATE TABLE t_ai;
 INSERT INTO t_ai (v) VALUES ('fresh_start');
 SELECT * FROM t_ai;
 id	v
-105	fresh_start
+1	fresh_start
+#
+# TEST 8: ALTER TABLE ... AUTO_INCREMENT=N takes effect
+#
+CREATE TABLE t_ai_alter (id INT AUTO_INCREMENT PRIMARY KEY, v VARCHAR(10)) ENGINE=TidesDB;
+INSERT INTO t_ai_alter (v) VALUES ('a'), ('b');
+ALTER TABLE t_ai_alter AUTO_INCREMENT=1000;
+INSERT INTO t_ai_alter (v) VALUES ('jumped');
+SELECT * FROM t_ai_alter ORDER BY id;
+id	v
+1	a
+2	b
+3	jumped
+DROP TABLE t_ai_alter;
 #
 # Cleanup
 #

--- a/mysql-test/suite/tidesdb/r/tidesdb_backup.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_backup.result
@@ -1,4 +1,4 @@
-CALL mtr.add_suppression("TIDESDB: Backup to .* failed");
+CALL mtr.add_suppression("\\[TIDESDB\\] Backup to .* failed");
 #
 # ============================================
 # TEST 1: Online backup creates a valid copy
@@ -34,7 +34,7 @@ DROP TABLE t_backup;
 #
 # Re-running backup to same directory should fail (not empty)
 SET GLOBAL tidesdb_backup_dir = 'MYSQLTEST_VARDIR/tmp/tidesdb_backup_test';
-ERROR HY000: TIDESDB: Backup to 'MYSQLTEST_VARDIR/tmp/tidesdb_backup_test' failed (err=-6)
+ERROR HY000: [TIDESDB] Backup to 'MYSQLTEST_VARDIR/tmp/tidesdb_backup_test' failed (err=-6)
 #
 # ============================================
 # TEST 3: Clear backup_dir variable

--- a/mysql-test/suite/tidesdb/r/tidesdb_concurrent_conflict.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_concurrent_conflict.result
@@ -1,4 +1,4 @@
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 #
 # Issue #77: Concurrent conflict detection
 #

--- a/mysql-test/suite/tidesdb/r/tidesdb_concurrent_errors.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_concurrent_errors.result
@@ -1,7 +1,7 @@
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_LOCKED");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_MEMORY_LIMIT");
-call mtr.add_suppression("TIDESDB:.*unexpected TidesDB error");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_LOCKED");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_MEMORY_LIMIT");
+call mtr.add_suppression("\\[TIDESDB\\].*unexpected TidesDB error");
 #
 # === Setup: sysbench-like schema ===
 #

--- a/mysql-test/suite/tidesdb/r/tidesdb_index_stats.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_index_stats.result
@@ -67,15 +67,15 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 ANALYZE TABLE t_stats;
 Table	Op	Msg_type	Msg_text
 test.t_stats	analyze	status	Engine-independent statistics collected
-test.t_stats	analyze	Note	TIDESDB: CF 'test__t_stats'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
-test.t_stats	analyze	Note	TIDESDB: avg_key=N bytes  avg_value=N bytes
-test.t_stats	analyze	Note	TIDESDB: level 1  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	TIDESDB: level 2  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	TIDESDB: level 3  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	TIDESDB: level 4  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	TIDESDB: level 5  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	TIDESDB: idx CF 'test__t_stats__idx_k_idx'  keys=N  data_size=N bytes  levels=5
-test.t_stats	analyze	Note	TIDESDB: idx 'k_idx' sampled=N distinct=N rec_per_key=N
+test.t_stats	analyze	Note	[TIDESDB] CF 'test__t_stats'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t_stats	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
+test.t_stats	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
+test.t_stats	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
+test.t_stats	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
+test.t_stats	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
+test.t_stats	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
+test.t_stats	analyze	Note	[TIDESDB] idx CF 'test__t_stats__idx_k_idx'  keys=N  data_size=N bytes  levels=5
+test.t_stats	analyze	Note	[TIDESDB] idx 'k_idx' sampled=N distinct=N rec_per_key=N
 test.t_stats	analyze	status	OK
 # After ANALYZE, the optimizer should estimate ~100 rows for k=0
 EXPLAIN SELECT * FROM t_stats WHERE k = 0;
@@ -95,15 +95,15 @@ KEY code_idx (code)
 ANALYZE TABLE t_stats2;
 Table	Op	Msg_type	Msg_text
 test.t_stats2	analyze	status	Engine-independent statistics collected
-test.t_stats2	analyze	Note	TIDESDB: CF 'test__t_stats2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
-test.t_stats2	analyze	Note	TIDESDB: avg_key=N bytes  avg_value=N bytes
-test.t_stats2	analyze	Note	TIDESDB: level 1  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	TIDESDB: level 2  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	TIDESDB: level 3  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	TIDESDB: level 4  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	TIDESDB: level 5  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	TIDESDB: idx CF 'test__t_stats2__idx_code_idx'  keys=N  data_size=N bytes  levels=5
-test.t_stats2	analyze	Note	TIDESDB: idx 'code_idx' sampled=N distinct=N rec_per_key=N
+test.t_stats2	analyze	Note	[TIDESDB] CF 'test__t_stats2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t_stats2	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
+test.t_stats2	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
+test.t_stats2	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
+test.t_stats2	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
+test.t_stats2	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
+test.t_stats2	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
+test.t_stats2	analyze	Note	[TIDESDB] idx CF 'test__t_stats2__idx_code_idx'  keys=N  data_size=N bytes  levels=5
+test.t_stats2	analyze	Note	[TIDESDB] idx 'code_idx' sampled=N distinct=N rec_per_key=N
 test.t_stats2	analyze	status	OK
 # With 100 distinct values in 100 rows, rec_per_key should be ~1
 EXPLAIN SELECT * FROM t_stats2 WHERE code = 50;

--- a/mysql-test/suite/tidesdb/r/tidesdb_insert_conflict.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_insert_conflict.result
@@ -1,4 +1,4 @@
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 #
 # Issue #83: INSERT vs INSERT conflict detection
 #

--- a/mysql-test/suite/tidesdb/r/tidesdb_mrr.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_mrr.result
@@ -1,0 +1,85 @@
+SET @saved_opt_switch = @@optimizer_switch;
+SET optimizer_switch = 'mrr=on,mrr_sort_keys=on,mrr_cost_based=off';
+#
+# TEST 1: IN (...) on PK (clustered-style point lookups)
+#
+CREATE TABLE t_pk (id INT PRIMARY KEY, v VARCHAR(20)) ENGINE=TidesDB;
+INSERT INTO t_pk VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),
+(6,'f'),(7,'g'),(8,'h'),(9,'i'),(10,'j');
+# Confirm the optimizer actually picks Rowid-ordered scan (MRR).
+EXPLAIN SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t_pk	range	PRIMARY	#	4	NULL	2	Using where
+# Unsorted IN-list; MRR must still return the right rows.
+SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5) ORDER BY id;
+id	v
+2	b
+3	c
+5	e
+7	g
+9	i
+# Mix of hits and misses -- missing IDs are silently skipped.
+SELECT * FROM t_pk WHERE id IN (11, 4, 99, 1, 42) ORDER BY id;
+id	v
+1	a
+4	d
+# Single-element IN is still routed through MRR.
+SELECT * FROM t_pk WHERE id IN (6);
+id	v
+6	f
+#
+# TEST 2: IN (...) on a unique secondary index
+#
+CREATE TABLE t_uk (
+id INT PRIMARY KEY,
+code INT,
+v VARCHAR(20),
+UNIQUE KEY u_code (code)
+) ENGINE=TidesDB;
+INSERT INTO t_uk VALUES (1,100,'a'),(2,200,'b'),(3,300,'c'),(4,400,'d'),(5,500,'e');
+SELECT * FROM t_uk WHERE code IN (300, 100, 500) ORDER BY code;
+id	code	v
+1	100	a
+3	300	c
+5	500	e
+SELECT * FROM t_uk WHERE code IN (999, 200, 111) ORDER BY code;
+id	code	v
+2	200	b
+#
+# TEST 3: Large unsorted IN-list (sort-then-seek should still be correct)
+#
+CREATE TABLE t_big (id INT PRIMARY KEY, v INT) ENGINE=TidesDB;
+SELECT COUNT(*), MIN(id), MAX(id) FROM t_big
+WHERE id IN (37, 199, 2, 88, 150, 1, 73, 112, 200, 5);
+COUNT(*)	MIN(id)	MAX(id)
+10	1	200
+# EXPLAIN should mention MRR in Extra for a 10-value IN on a 200-row table.
+EXPLAIN SELECT * FROM t_big
+WHERE id IN (37, 199, 2, 88, 150, 1, 73, 112, 200, 5);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t_big	range	PRIMARY	#	4	NULL	#	Using where
+#
+# TEST 4: Result is consistent with / without MRR
+#
+SET optimizer_switch = 'mrr=off';
+SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5) ORDER BY id;
+id	v
+2	b
+3	c
+5	e
+7	g
+9	i
+SET optimizer_switch = 'mrr=on,mrr_sort_keys=on,mrr_cost_based=off';
+SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5) ORDER BY id;
+id	v
+2	b
+3	c
+5	e
+7	g
+9	i
+#
+# Cleanup
+#
+DROP TABLE t_pk, t_uk, t_big;
+SET optimizer_switch = @saved_opt_switch;
+# Done.

--- a/mysql-test/suite/tidesdb/r/tidesdb_pessimistic_forupdate.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_pessimistic_forupdate.result
@@ -1,4 +1,4 @@
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 #
 # Setup: TPC-C district-like table
 #

--- a/mysql-test/suite/tidesdb/r/tidesdb_pessimistic_insert_lock.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_pessimistic_insert_lock.result
@@ -1,4 +1,4 @@
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 #
 # Setup
 #

--- a/mysql-test/suite/tidesdb/r/tidesdb_write_pressure.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_write_pressure.result
@@ -1,7 +1,7 @@
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_LOCKED");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_MEMORY_LIMIT");
-call mtr.add_suppression("TIDESDB:.*unexpected TidesDB error");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_LOCKED");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_MEMORY_LIMIT");
+call mtr.add_suppression("\\[TIDESDB\\].*unexpected TidesDB error");
 #
 # === Setup: sysbench-like schema with SYNC_MODE=NONE ===
 #

--- a/mysql-test/suite/tidesdb/t/tidesdb_auto_increment.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_auto_increment.test
@@ -70,6 +70,17 @@ INSERT INTO t_ai (v) VALUES ('fresh_start');
 SELECT * FROM t_ai;
 
 --echo #
+--echo # TEST 8: ALTER TABLE ... AUTO_INCREMENT=N takes effect
+--echo #
+
+CREATE TABLE t_ai_alter (id INT AUTO_INCREMENT PRIMARY KEY, v VARCHAR(10)) ENGINE=TidesDB;
+INSERT INTO t_ai_alter (v) VALUES ('a'), ('b');
+ALTER TABLE t_ai_alter AUTO_INCREMENT=1000;
+INSERT INTO t_ai_alter (v) VALUES ('jumped');
+SELECT * FROM t_ai_alter ORDER BY id;
+DROP TABLE t_ai_alter;
+
+--echo #
 --echo # Cleanup
 --echo #
 

--- a/mysql-test/suite/tidesdb/t/tidesdb_backup.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_backup.test
@@ -3,7 +3,7 @@
 
 
 # Suppress expected error from Test 2 (backup to non-empty dir)
-CALL mtr.add_suppression("TIDESDB: Backup to .* failed");
+CALL mtr.add_suppression("\\[TIDESDB\\] Backup to .* failed");
 
 --echo #
 --echo # ============================================

--- a/mysql-test/suite/tidesdb/t/tidesdb_concurrent_conflict.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_concurrent_conflict.test
@@ -5,7 +5,7 @@
 # two transactions modify the same row.
 #
 
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 
 --echo #
 --echo # Issue #77: Concurrent conflict detection

--- a/mysql-test/suite/tidesdb/t/tidesdb_concurrent_errors.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_concurrent_errors.test
@@ -21,10 +21,10 @@
 #
 
 # Suppress expected warnings from the new tdb_rc_to_ha() error mapper
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_LOCKED");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_MEMORY_LIMIT");
-call mtr.add_suppression("TIDESDB:.*unexpected TidesDB error");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_LOCKED");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_MEMORY_LIMIT");
+call mtr.add_suppression("\\[TIDESDB\\].*unexpected TidesDB error");
 
 --echo #
 --echo # === Setup: sysbench-like schema ===

--- a/mysql-test/suite/tidesdb/t/tidesdb_insert_conflict.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_insert_conflict.test
@@ -8,7 +8,7 @@
 # conflict detection.  If it fails, the library may need updating.
 #
 
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 
 --echo #
 --echo # Issue #83: INSERT vs INSERT conflict detection

--- a/mysql-test/suite/tidesdb/t/tidesdb_mrr.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_mrr.test
@@ -1,0 +1,89 @@
+--source include/have_tidesdb.inc
+#
+# Multi-Range Read (MRR) for TidesDB.
+#
+# Exercises the custom MRR path that batches and sorts point lookups from
+# WHERE col IN (...) style queries.  Verifies correctness with and without
+# the optimizer_switch that forces MRR, across PK and secondary indexes,
+# and on a large IN-list where the sort matters for locality.
+#
+
+SET @saved_opt_switch = @@optimizer_switch;
+SET optimizer_switch = 'mrr=on,mrr_sort_keys=on,mrr_cost_based=off';
+
+--echo #
+--echo # TEST 1: IN (...) on PK (clustered-style point lookups)
+--echo #
+
+CREATE TABLE t_pk (id INT PRIMARY KEY, v VARCHAR(20)) ENGINE=TidesDB;
+INSERT INTO t_pk VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),
+                        (6,'f'),(7,'g'),(8,'h'),(9,'i'),(10,'j');
+
+--echo # Confirm the optimizer actually picks Rowid-ordered scan (MRR).
+--replace_column 6 #
+EXPLAIN SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5);
+
+--echo # Unsorted IN-list; MRR must still return the right rows.
+SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5) ORDER BY id;
+
+--echo # Mix of hits and misses -- missing IDs are silently skipped.
+SELECT * FROM t_pk WHERE id IN (11, 4, 99, 1, 42) ORDER BY id;
+
+--echo # Single-element IN is still routed through MRR.
+SELECT * FROM t_pk WHERE id IN (6);
+
+--echo #
+--echo # TEST 2: IN (...) on a unique secondary index
+--echo #
+
+CREATE TABLE t_uk (
+  id INT PRIMARY KEY,
+  code INT,
+  v VARCHAR(20),
+  UNIQUE KEY u_code (code)
+) ENGINE=TidesDB;
+INSERT INTO t_uk VALUES (1,100,'a'),(2,200,'b'),(3,300,'c'),(4,400,'d'),(5,500,'e');
+
+SELECT * FROM t_uk WHERE code IN (300, 100, 500) ORDER BY code;
+SELECT * FROM t_uk WHERE code IN (999, 200, 111) ORDER BY code;
+
+--echo #
+--echo # TEST 3: Large unsorted IN-list (sort-then-seek should still be correct)
+--echo #
+
+CREATE TABLE t_big (id INT PRIMARY KEY, v INT) ENGINE=TidesDB;
+--disable_query_log
+let $i = 1;
+while ($i <= 200)
+{
+  eval INSERT INTO t_big VALUES ($i, $i * 10);
+  inc $i;
+}
+--enable_query_log
+
+SELECT COUNT(*), MIN(id), MAX(id) FROM t_big
+  WHERE id IN (37, 199, 2, 88, 150, 1, 73, 112, 200, 5);
+
+--echo # EXPLAIN should mention MRR in Extra for a 10-value IN on a 200-row table.
+--replace_column 6 # 9 #
+EXPLAIN SELECT * FROM t_big
+  WHERE id IN (37, 199, 2, 88, 150, 1, 73, 112, 200, 5);
+
+--echo #
+--echo # TEST 4: Result is consistent with / without MRR
+--echo #
+
+SET optimizer_switch = 'mrr=off';
+SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5) ORDER BY id;
+SET optimizer_switch = 'mrr=on,mrr_sort_keys=on,mrr_cost_based=off';
+SELECT * FROM t_pk WHERE id IN (7, 2, 9, 3, 5) ORDER BY id;
+
+--echo #
+--echo # Cleanup
+--echo #
+
+DROP TABLE t_pk, t_uk, t_big;
+SET optimizer_switch = @saved_opt_switch;
+
+--source suite/tidesdb/include/cleanup_tidesdb.inc
+--echo # Done.

--- a/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_forupdate.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_forupdate.test
@@ -11,7 +11,7 @@
 #   - Zero conflict errors
 #
 
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 
 # pessimistic_locking=ON is set via .opt file
 

--- a/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_insert_lock.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_pessimistic_insert_lock.test
@@ -10,7 +10,7 @@
 #   5. Concurrent INSERTs on different keys do not block
 #
 
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
 
 --echo #
 --echo # Setup

--- a/mysql-test/suite/tidesdb/t/tidesdb_write_pressure.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_write_pressure.test
@@ -14,10 +14,10 @@
 #
 
 # Suppress expected conflict warnings from concurrent writes
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_CONFLICT");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_LOCKED");
-call mtr.add_suppression("TIDESDB:.*TDB_ERR_MEMORY_LIMIT");
-call mtr.add_suppression("TIDESDB:.*unexpected TidesDB error");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_CONFLICT");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_LOCKED");
+call mtr.add_suppression("\\[TIDESDB\\].*TDB_ERR_MEMORY_LIMIT");
+call mtr.add_suppression("\\[TIDESDB\\].*unexpected TidesDB error");
 
 --echo #
 --echo # === Setup: sysbench-like schema with SYNC_MODE=NONE ===

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -98,7 +98,7 @@ static int tdb_rc_to_ha(int rc, const char *ctx)
             return HA_ERR_LOCK_DEADLOCK;
 
         case TDB_ERR_MEMORY:
-            sql_print_error("TIDESDB: %s: TDB_ERR_MEMORY (-1)", ctx);
+            sql_print_error("[TIDESDB] %s: TDB_ERR_MEMORY (-1)", ctx);
             return HA_ERR_OUT_OF_MEM;
 
         case TDB_ERR_NOT_FOUND:
@@ -113,11 +113,11 @@ static int tdb_rc_to_ha(int rc, const char *ctx)
         /* I/O and corruption errors -- table needs repair/recovery.
            matches InnoDB's mapping of DB_CORRUPTION to HA_ERR_CRASHED. */
         case TDB_ERR_IO:
-            sql_print_error("TIDESDB: %s: I/O error (TDB_ERR_IO)", ctx);
+            sql_print_error("[TIDESDB] %s: I/O error (TDB_ERR_IO)", ctx);
             return HA_ERR_CRASHED;
 
         case TDB_ERR_CORRUPTION:
-            sql_print_error("TIDESDB: %s: data corruption detected (TDB_ERR_CORRUPTION)", ctx);
+            sql_print_error("[TIDESDB] %s: data corruption detected (TDB_ERR_CORRUPTION)", ctx);
             return HA_ERR_CRASHED;
 
         /* Row too large for the configured block/value size. */
@@ -126,16 +126,16 @@ static int tdb_rc_to_ha(int rc, const char *ctx)
 
         /* Database handle invalid (closed or never opened). */
         case TDB_ERR_INVALID_DB:
-            sql_print_error("TIDESDB: %s: invalid database handle (TDB_ERR_INVALID_DB)", ctx);
+            sql_print_error("[TIDESDB] %s: invalid database handle (TDB_ERR_INVALID_DB)", ctx);
             return HA_ERR_INTERNAL_ERROR;
 
         /* Invalid arguments -- programming error in the plugin. */
         case TDB_ERR_INVALID_ARGS:
-            sql_print_error("TIDESDB: %s: invalid arguments (TDB_ERR_INVALID_ARGS)", ctx);
+            sql_print_error("[TIDESDB] %s: invalid arguments (TDB_ERR_INVALID_ARGS)", ctx);
             return HA_ERR_INTERNAL_ERROR;
 
         default:
-            sql_print_warning("TIDESDB: %s: unexpected TidesDB error rc=%d", ctx, rc);
+            sql_print_warning("[TIDESDB] %s: unexpected TidesDB error rc=%d", ctx, rc);
             return HA_ERR_GENERIC;
     }
 }
@@ -178,18 +178,24 @@ static constexpr ulong ROW_LOCK_PARTITIONS = 65536;
    Prevents infinite loops on corrupted graph state. */
 static constexpr int DEADLOCK_MAX_DEPTH = 100;
 
-/* Row lock entry in the hash table */
+/* Row lock entry in the hash table.
+   owner_txn_id and owner_trx are read by deadlock graph walks running on
+   OTHER threads without holding this partition's mutex -- they must be
+   atomic so readers never observe a torn write.  All writes still happen
+   under the owning partition's mutex.  Lock entries are never freed once
+   created (only the owner fields reset to 0/null on release), so pointers
+   traversed during the walk always point to valid memory. */
 struct tdb_row_lock_t
 {
-    uchar *pk;                 /* heap-allocated PK bytes */
-    uint pk_len;               /* length of PK bytes */
-    uint64_t owner_txn_id;     /* txn that holds this lock (0 = free) */
-    tidesdb_trx_t *owner_trx;  /* trx struct of the holder */
-    mysql_cond_t cond;         /* waiters sleep on this */
-    uint waiters;              /* number of threads waiting */
-    tdb_row_lock_t *hash_next; /* next in hash chain */
-    tdb_row_lock_t *held_next; /* next in per-txn held list */
-    uint partition;            /* which partition this belongs to */
+    uchar *pk;                              /* heap-allocated PK bytes */
+    uint pk_len;                            /* length of PK bytes */
+    std::atomic<uint64_t> owner_txn_id;     /* txn that holds this lock (0 = free) */
+    std::atomic<tidesdb_trx_t *> owner_trx; /* trx struct of the holder */
+    mysql_cond_t cond;                      /* waiters sleep on this */
+    uint waiters;                           /* number of threads waiting (mutex-guarded) */
+    tdb_row_lock_t *hash_next;              /* next in hash chain (mutex-guarded) */
+    tdb_row_lock_t *held_next;              /* next in per-txn held list (owner-only) */
+    uint partition;                         /* which partition this belongs to */
 };
 
 /* One partition of the lock table */
@@ -227,8 +233,8 @@ static tdb_row_lock_t *tdb_lock_find_or_create(tdb_lock_partition_t *part, uint 
     }
     memcpy(e->pk, pk, pk_len);
     e->pk_len = pk_len;
-    e->owner_txn_id = 0;
-    e->owner_trx = NULL;
+    e->owner_txn_id.store(0, std::memory_order_relaxed);
+    e->owner_trx.store(NULL, std::memory_order_relaxed);
     e->waiters = 0;
     e->partition = part_idx;
     mysql_cond_init(0, &e->cond, NULL);
@@ -237,22 +243,29 @@ static tdb_row_lock_t *tdb_lock_find_or_create(tdb_lock_partition_t *part, uint 
     return e;
 }
 
-/* Deadlock detection--we walk the wait-for graph.
-   Returns true if acquiring this lock would create a cycle.
-   Caller must not hold any partition mutex (we acquire them during traversal). */
+/* Deadlock detection -- walk the wait-for graph with atomic loads.
+   Returns true if the requestor waiting on target_lock would create a cycle.
+
+   The walk does not hold any partition mutex, lock and trx structs are never
+   freed (locks stay in their hash chain for the lifetime of the plugin; trx
+   structs are freed only at connection close, which requires the connection
+   to have released all locks first).  The owner / waiting_on fields are
+   atomic so that cross-partition reads never tear.  Racy state observed
+   during the walk can produce a stale answer (false positive rare spurious
+   deadlock return, application retries; false negative wait and rely on
+   the lock-wait-timeout to recover).  Neither outcome corrupts memory. */
 static bool tdb_lock_would_deadlock(tidesdb_trx_t *requestor, tdb_row_lock_t *target_lock)
 {
-    /* We follow the chain
-       requestor wants target_lock -> target_lock.owner_trx -> owner.waiting_on -> ...
-       If we reach requestor, there's a cycle.  Depth capped at
-       DEADLOCK_MAX_DEPTH to avoid infinite loops on corrupted state. */
-    tidesdb_trx_t *cur = target_lock->owner_trx;
+    /* Chain is requestor -> target_lock -> target_lock.owner_trx ->
+       owner.waiting_on -> ... -- if we reach the requestor there's a cycle.
+       Depth capped at DEADLOCK_MAX_DEPTH to avoid pathological runs. */
+    tidesdb_trx_t *cur = target_lock->owner_trx.load(std::memory_order_acquire);
     for (int depth = 0; depth < DEADLOCK_MAX_DEPTH && cur; depth++)
     {
-        if (cur == requestor) return true; /* cycle found */
-        tdb_row_lock_t *cur_waiting = cur->waiting_on;
-        if (!cur_waiting) break; /* not waiting on anything */
-        cur = cur_waiting->owner_trx;
+        if (cur == requestor) return true; /* cycle */
+        tdb_row_lock_t *cur_waiting = cur->waiting_on.load(std::memory_order_acquire);
+        if (!cur_waiting) break; /* not currently waiting */
+        cur = cur_waiting->owner_trx.load(std::memory_order_acquire);
     }
     return false;
 }
@@ -260,7 +273,14 @@ static bool tdb_lock_would_deadlock(tidesdb_trx_t *requestor, tdb_row_lock_t *ta
 /*
   Acquire a row lock. Returns 0 on success, HA_ERR_LOCK_DEADLOCK on deadlock.
   Blocks if the row is locked by another transaction (unless deadlock detected).
-  Re-entrant--returns immediately if already held by this txn.
+  Re-entrant -- returns immediately if already held by this txn.
+
+  Deadlock detection runs without the partition mutex held we publish our
+  wait intent (trx->waiting_on) under the mutex so other walkers see us,
+  drop the mutex, walk the wait-for graph with atomic loads, then re-acquire.
+  This keeps other lockers on the same partition unblocked while we walk
+  and removes the data races that the old code had when traversing pointers
+  in unrelated partitions.
 */
 static int row_lock_acquire(tidesdb_trx_t *trx, const uchar *key, uint len)
 {
@@ -279,43 +299,67 @@ static int row_lock_acquire(tidesdb_trx_t *trx, const uchar *key, uint len)
     }
 
     /* Already own it? */
-    if (lock->owner_txn_id == trx->lock_txn_id && lock->owner_trx == trx)
+    if (lock->owner_txn_id.load(std::memory_order_relaxed) == trx->lock_txn_id &&
+        lock->owner_trx.load(std::memory_order_relaxed) == trx)
     {
         mysql_mutex_unlock(&part->mutex);
         return 0;
     }
 
     /* Free? Claim it. */
-    if (lock->owner_txn_id == 0)
+    if (lock->owner_txn_id.load(std::memory_order_relaxed) == 0)
     {
-        lock->owner_txn_id = trx->lock_txn_id;
-        lock->owner_trx = trx;
+        lock->owner_txn_id.store(trx->lock_txn_id, std::memory_order_release);
+        lock->owner_trx.store(trx, std::memory_order_release);
         lock->held_next = trx->held_locks_head;
         trx->held_locks_head = lock;
         mysql_mutex_unlock(&part->mutex);
         return 0;
     }
 
-    /* Owned by someone else -- we check for deadlock before waiting */
-    if (tdb_lock_would_deadlock(trx, lock))
+    /* Owned by someone else -- publish our wait intent so concurrent deadlock
+       walks that traverse through this trx can see what we're waiting on,
+       then drop the mutex to run the walk without blocking our partition. */
+    trx->waiting_on.store(lock, std::memory_order_release);
+    mysql_mutex_unlock(&part->mutex);
+
+    bool deadlock = tdb_lock_would_deadlock(trx, lock);
+
+    mysql_mutex_lock(&part->mutex);
+
+    if (deadlock)
     {
+        trx->waiting_on.store(NULL, std::memory_order_relaxed);
         mysql_mutex_unlock(&part->mutex);
         return HA_ERR_LOCK_DEADLOCK;
     }
 
-    /* We wait for the lock to be released */
-    trx->waiting_on = lock;
+    /* The owner may have released while we were walking.  If so, claim the
+       lock directly instead of falling through to cond_wait. */
+    if (lock->owner_txn_id.load(std::memory_order_relaxed) == 0)
+    {
+        lock->owner_txn_id.store(trx->lock_txn_id, std::memory_order_release);
+        lock->owner_trx.store(trx, std::memory_order_release);
+        lock->held_next = trx->held_locks_head;
+        trx->held_locks_head = lock;
+        trx->waiting_on.store(NULL, std::memory_order_relaxed);
+        mysql_mutex_unlock(&part->mutex);
+        return 0;
+    }
+
+    /* Still owned -- wait for release. */
     lock->waiters++;
-    while (lock->owner_txn_id != 0 && lock->owner_trx != trx)
+    while (lock->owner_txn_id.load(std::memory_order_relaxed) != 0 &&
+           lock->owner_trx.load(std::memory_order_relaxed) != trx)
     {
         mysql_cond_wait(&lock->cond, &part->mutex);
     }
     lock->waiters--;
-    trx->waiting_on = NULL;
+    trx->waiting_on.store(NULL, std::memory_order_relaxed);
 
     /* We claim the lock */
-    lock->owner_txn_id = trx->lock_txn_id;
-    lock->owner_trx = trx;
+    lock->owner_txn_id.store(trx->lock_txn_id, std::memory_order_release);
+    lock->owner_trx.store(trx, std::memory_order_release);
     lock->held_next = trx->held_locks_head;
     trx->held_locks_head = lock;
     mysql_mutex_unlock(&part->mutex);
@@ -338,8 +382,8 @@ static void row_locks_release_all(tidesdb_trx_t *trx)
         tdb_lock_partition_t *part = &lock_partitions[part_idx];
 
         mysql_mutex_lock(&part->mutex);
-        lock->owner_txn_id = 0;
-        lock->owner_trx = NULL;
+        lock->owner_txn_id.store(0, std::memory_order_release);
+        lock->owner_trx.store(NULL, std::memory_order_release);
         lock->held_next = NULL;
         if (lock->waiters > 0) mysql_cond_broadcast(&lock->cond);
         mysql_mutex_unlock(&part->mutex);
@@ -347,7 +391,7 @@ static void row_locks_release_all(tidesdb_trx_t *trx)
         lock = next;
     }
     trx->held_locks_head = NULL;
-    trx->waiting_on = NULL;
+    trx->waiting_on.store(NULL, std::memory_order_relaxed);
 }
 
 static handler *tidesdb_create_handler(handlerton *hton, TABLE_SHARE *table, MEM_ROOT *mem_root);
@@ -463,6 +507,32 @@ static void tdb_fts_reinit_search(FT_INFO *fts)
    (170+ 3-byte UTF-8 characters). */
 static constexpr uint FTS_MAX_TERM_BYTES = 512;
 
+/* Size of the leading 2-byte little-endian term-length field on every
+   FTS inverted-index entry key. */
+static constexpr uint FTS_TERM_LEN_PREFIX = 2;
+
+/* Worst-case FTS entry key buffer-- [2B term_len][term bytes][PK]. */
+static constexpr uint FTS_KEY_BUF_LEN = FTS_TERM_LEN_PREFIX + FTS_MAX_TERM_BYTES + MAX_KEY_LENGTH;
+
+/* FTS entry value layout: [2B tf LE][4B doc_len LE] = 6 bytes. */
+static constexpr uint FTS_VALUE_TF_LEN = 2;
+static constexpr uint FTS_VALUE_DOC_LEN_OFFSET = FTS_VALUE_TF_LEN;
+static constexpr uint FTS_VALUE_DOC_LEN_LEN = 4;
+static constexpr uint FTS_VALUE_LEN = FTS_VALUE_TF_LEN + FTS_VALUE_DOC_LEN_LEN;
+
+/* FTS per-index meta key layout:
+   [KEY_NS_META(1B)][FTS tag(4B incl NUL)][keynr(1B)] = 6 bytes.
+   Meta value layout: [8B total_docs][8B total_words] = 16 bytes. */
+static constexpr const char FTS_META_KEY_TAG[] = "FTS\x00";
+static constexpr uint FTS_META_KEY_TAG_LEN = 4; /* 3 letters + trailing NUL */
+static constexpr uint FTS_META_KEY_TAG_OFFSET = KEY_NAMESPACE_LEN;
+static constexpr uint FTS_META_KEY_KEYNR_OFFSET = FTS_META_KEY_TAG_OFFSET + FTS_META_KEY_TAG_LEN;
+static constexpr uint FTS_META_KEY_LEN = FTS_META_KEY_KEYNR_OFFSET + 1;
+static constexpr uint FTS_META_VALUE_DOCS_LEN = 8;
+static constexpr uint FTS_META_VALUE_WORDS_OFFSET = FTS_META_VALUE_DOCS_LEN;
+static constexpr uint FTS_META_VALUE_WORDS_LEN = 8;
+static constexpr uint FTS_META_VALUE_LEN = FTS_META_VALUE_DOCS_LEN + FTS_META_VALUE_WORDS_LEN;
+
 /* Build an FTS inverted index key:
    [2-byte term_len LE][lowercased term bytes][comparable PK bytes]
    Returns total key length.  Term is silently truncated to FTS_MAX_TERM_BYTES. */
@@ -471,7 +541,7 @@ static uint fts_build_key(const char *term, uint term_len, const uchar *pk, uint
     if (term_len > FTS_MAX_TERM_BYTES) term_len = FTS_MAX_TERM_BYTES;
     uint pos = 0;
     int2store(out + pos, (uint16)term_len);
-    pos += 2;
+    pos += FTS_TERM_LEN_PREFIX;
     memcpy(out + pos, term, term_len);
     pos += term_len;
     memcpy(out + pos, pk, pk_len);
@@ -479,34 +549,34 @@ static uint fts_build_key(const char *term, uint term_len, const uchar *pk, uint
     return pos;
 }
 
-/* Build FTS value ( [2-byte tf LE][4-byte doc_len LE] ) = 6 bytes */
+/* Build FTS value ( [2-byte tf LE][4-byte doc_len LE] ) = FTS_VALUE_LEN bytes */
 static uint fts_build_value(uint16 tf, uint32 doc_len, uchar *out)
 {
     int2store(out, tf);
-    int4store(out + 2, doc_len);
-    return 6;
+    int4store(out + FTS_VALUE_DOC_LEN_OFFSET, doc_len);
+    return FTS_VALUE_LEN;
 }
 
 /* Read or initialize FTS metadata counters from the data CF.
-   Key format ( [KEY_NS_META][FTS\x00][keynr] )*/
+   Key format: [KEY_NS_META][FTS tag][keynr]. */
 static int fts_load_meta(tidesdb_txn_t *txn, tidesdb_column_family_t *data_cf, uint keynr,
                          int64_t *total_docs, int64_t *total_words)
 {
-    uchar mk[6];
+    uchar mk[FTS_META_KEY_LEN];
     mk[0] = KEY_NS_META;
-    memcpy(mk + 1, "FTS\x00", 4);
-    mk[5] = (uchar)keynr;
+    memcpy(mk + FTS_META_KEY_TAG_OFFSET, FTS_META_KEY_TAG, FTS_META_KEY_TAG_LEN);
+    mk[FTS_META_KEY_KEYNR_OFFSET] = (uchar)keynr;
 
     uint8_t *val = NULL;
     size_t vlen = 0;
     *total_docs = 0;
     *total_words = 0;
 
-    int rc = tidesdb_txn_get(txn, data_cf, mk, 6, &val, &vlen);
-    if (rc == TDB_SUCCESS && vlen >= 16)
+    int rc = tidesdb_txn_get(txn, data_cf, mk, FTS_META_KEY_LEN, &val, &vlen);
+    if (rc == TDB_SUCCESS && vlen >= FTS_META_VALUE_LEN)
     {
         *total_docs = sint8korr(val);
-        *total_words = sint8korr(val + 8);
+        *total_words = sint8korr(val + FTS_META_VALUE_WORDS_OFFSET);
         tidesdb_free(val);
     }
     else if (val)
@@ -528,15 +598,16 @@ static int fts_update_meta(tidesdb_txn_t *txn, tidesdb_column_family_t *data_cf,
     if (total_docs < 0) total_docs = 0;
     if (total_words < 0) total_words = 0;
 
-    uchar mk[6];
+    uchar mk[FTS_META_KEY_LEN];
     mk[0] = KEY_NS_META;
-    memcpy(mk + 1, "FTS\x00", 4);
-    mk[5] = (uchar)keynr;
+    memcpy(mk + FTS_META_KEY_TAG_OFFSET, FTS_META_KEY_TAG, FTS_META_KEY_TAG_LEN);
+    mk[FTS_META_KEY_KEYNR_OFFSET] = (uchar)keynr;
 
-    uchar mv[16];
+    uchar mv[FTS_META_VALUE_LEN];
     int8store(mv, total_docs);
-    int8store(mv + 8, total_words);
-    return tidesdb_txn_put(txn, data_cf, mk, 6, mv, 16, (time_t)-1);
+    int8store(mv + FTS_META_VALUE_WORDS_OFFSET, total_words);
+    return tidesdb_txn_put(txn, data_cf, mk, FTS_META_KEY_LEN, mv, FTS_META_VALUE_LEN,
+                           TIDESDB_TTL_NONE);
 }
 
 /* Tokenize a text string using MariaDB's default FT parser.
@@ -554,7 +625,7 @@ static ulong srv_fts_max_word_len = 84;
 
 /* Blend characters -- characters that are indexed as both separators and valid
    word characters.  When a blend char appears inside a token, the tokenizer
-   emits THREE tokens: the full blended form, and the two parts on each side.
+   emits three tokens -- the full blended form, and the two parts on each side.
    For example, with blend_chars="'" and input "l'aria":
      - "l'aria" (full blended token)
      - "l"      (left part, may be filtered by min_word_len)
@@ -564,9 +635,10 @@ static ulong srv_fts_max_word_len = 84;
    Default is empty (no blend characters). Set to "'" for Romance languages. */
 static char *srv_fts_blend_chars = NULL;
 
-/* Fast lookup table for blend characters (ASCII range).
-   Rebuilt when the sysvar changes. */
-static bool tdb_blend_char_map[256] = {false};
+/* Fast lookup table for blend characters, indexed by raw byte value
+   (covers the full 8-bit range).  Rebuilt when the sysvar changes. */
+static constexpr uint TDB_BLEND_MAP_SIZE = 256;
+static bool tdb_blend_char_map[TDB_BLEND_MAP_SIZE] = {false};
 static mysql_rwlock_t tdb_blend_lock;
 static PSI_rwlock_key tdb_blend_lock_key;
 
@@ -591,9 +663,9 @@ static void tdb_fts_blend_chars_update(MYSQL_THD thd, struct st_mysql_sys_var *v
     mysql_rwlock_unlock(&tdb_blend_lock);
     *static_cast<const char **>(var_ptr) = new_val;
     if (new_val && new_val[0])
-        sql_print_information("TIDESDB: FTS blend_chars set to '%s'", new_val);
+        sql_print_information("[TIDESDB] FTS blend_chars set to '%s'", new_val);
     else
-        sql_print_information("TIDESDB: FTS blend_chars cleared");
+        sql_print_information("[TIDESDB] FTS blend_chars cleared");
 }
 
 /* ---- Stop word support ------------------------------------------------
@@ -622,13 +694,12 @@ static void tdb_load_default_stopwords()
     for (const char **w = tdb_default_stopwords; *w; w++) tdb_stopwords.insert(*w);
 }
 
-/* Check if a lowercased token is a stop word */
-static inline bool tdb_is_stopword(const std::string &word)
+/* Check if a lowercased token is a stop word.
+   PRECONDITION caller holds tdb_stopword_lock for reading (taken once per
+   fts_tokenize call to avoid N lock pairs per document). */
+static inline bool tdb_is_stopword_locked(const std::string &word)
 {
-    mysql_rwlock_rdlock(&tdb_stopword_lock);
-    bool found = tdb_stopwords.count(word) > 0;
-    mysql_rwlock_unlock(&tdb_stopword_lock);
-    return found;
+    return tdb_stopwords.count(word) > 0;
 }
 
 /* Load stop words from a user table specified as "db_name/table_name".
@@ -644,7 +715,7 @@ static bool tdb_load_stopwords_from_table_spec(const char *table_spec)
     const char *slash = strchr(table_spec, '/');
     if (!slash)
     {
-        sql_print_error("TIDESDB: ft_stopword_table format must be 'db_name/table_name', got '%s'",
+        sql_print_error("[TIDESDB] ft_stopword_table format must be 'db_name/table_name', got '%s'",
                         table_spec);
         return false;
     }
@@ -660,7 +731,7 @@ static bool tdb_load_stopwords_from_table_spec(const char *table_spec)
     if (!sw_cf)
     {
         sql_print_warning(
-            "TIDESDB: Stop word table '%s' not found as TidesDB CF '%s'. "
+            "[TIDESDB] Stop word table '%s' not found as TidesDB CF '%s'. "
             "The table must be a TidesDB ENGINE table. Keeping current stop words.",
             table_spec, cf_name.c_str());
         return false;
@@ -687,14 +758,14 @@ static bool tdb_load_stopwords_from_table_spec(const char *table_spec)
         size_t val_size = 0;
         if (tidesdb_iter_value(iter, &val, &val_size) == TDB_SUCCESS && val && val_size > 0)
         {
-            /* The row is in our packed format: [header][null_bitmap][fields...].
+            /* The row is in our packed format-- [header][null_bitmap][fields...].
                For a simple single-column VARCHAR table, the value starts after the
                5-byte header + null bitmap. For robustness, just treat the entire
                value as the word if it's short enough. We skip the header bytes. */
             const uint8_t *data = val;
             size_t data_len = val_size;
 
-            /* We skip row header (5 bytes: magic + null_bytes_stored + field_count) */
+            /* We skip row header (5 bytes-- magic + null_bytes_stored + field_count) */
             if (data_len > 5)
             {
                 data += 5;
@@ -727,7 +798,7 @@ static bool tdb_load_stopwords_from_table_spec(const char *table_spec)
     tidesdb_iter_free(iter);
     tidesdb_txn_free(txn);
 
-    sql_print_information("TIDESDB: Loaded %zu stop words from table '%s'", tdb_stopwords.size(),
+    sql_print_information("[TIDESDB] Loaded %zu stop words from table '%s'", tdb_stopwords.size(),
                           table_spec);
     return true;
 }
@@ -743,7 +814,7 @@ static void tdb_ft_stopword_table_update(MYSQL_THD thd, struct st_mysql_sys_var 
     {
         /* NULL or empty string -- we reset to defaults */
         tdb_load_default_stopwords();
-        sql_print_information("TIDESDB: Stop words reset to defaults (%zu words)",
+        sql_print_information("[TIDESDB] Stop words reset to defaults (%zu words)",
                               tdb_stopwords.size());
     }
     else
@@ -751,7 +822,7 @@ static void tdb_ft_stopword_table_update(MYSQL_THD thd, struct st_mysql_sys_var 
         /* We try to load from user table */
         if (!tdb_load_stopwords_from_table_spec(new_val))
         {
-            sql_print_warning("TIDESDB: Failed to load stop words from '%s', keeping current set",
+            sql_print_warning("[TIDESDB] Failed to load stop words from '%s', keeping current set",
                               new_val);
         }
     }
@@ -778,7 +849,7 @@ static inline void fts_emit_token(const char *word_start, size_t byte_len, uint 
         cs->cset->casedn(cs, &tok.word[0], tok.word.size(), &tok.word[0], tok.word.size());
     tok.word.resize(lowered_len);
 
-    if (tdb_is_stopword(tok.word)) return;
+    if (tdb_is_stopword_locked(tok.word)) return;
     out.push_back(std::move(tok));
 }
 
@@ -790,7 +861,7 @@ static inline void fts_emit_token(const char *word_start, size_t byte_len, uint 
 
    Blend characters (configured via tidesdb_fts_blend_chars) are treated as
    both word characters and separators.  When a blend char appears inside a
-   token, the tokenizer emits three forms: the full blended token, and the
+   token, the tokenizer emits three forms-- the full blended token, and the
    two parts on each side of the blend char.  This enables Romance language
    elision (l'aria -> l'aria + aria) and names (O'Malley -> o'malley + malley)
    to be searchable by any component or the full form. */
@@ -803,14 +874,20 @@ static void fts_tokenize(const char *text, size_t text_len, CHARSET_INFO *cs,
 
     /* We snapshot blend chars under read lock once per tokenize call */
     bool has_blend = false;
-    bool blend_map_copy[256];
+    bool blend_map_copy[TDB_BLEND_MAP_SIZE];
     {
         mysql_rwlock_rdlock(&tdb_blend_lock);
         memcpy(blend_map_copy, tdb_blend_char_map, sizeof(blend_map_copy));
         mysql_rwlock_unlock(&tdb_blend_lock);
-        for (int i = 0; i < 256 && !has_blend; i++)
+        for (uint i = 0; i < TDB_BLEND_MAP_SIZE && !has_blend; i++)
             if (blend_map_copy[i]) has_blend = true;
     }
+
+    /* We hold the stopword rdlock once for the whole tokenize pass.
+       fts_emit_token calls tdb_is_stopword_locked which assumes the read
+       lock is held -- this avoids the N lock-pair cost the previous
+       per-token acquisition incurred (1000-word doc = 1000 lock pairs). */
+    mysql_rwlock_rdlock(&tdb_stopword_lock);
 
     while (p < end)
     {
@@ -890,6 +967,8 @@ static void fts_tokenize(const char *text, size_t text_len, CHARSET_INFO *cs,
             if (sub_len > 0) fts_emit_token(sub_start, sub_len, sub_chars, cs, out);
         }
     }
+
+    mysql_rwlock_unlock(&tdb_stopword_lock);
 }
 
 /* Extract and tokenize the document from all FULLTEXT key_part fields.
@@ -1040,20 +1119,15 @@ static void fts_parse_boolean(const char *query, size_t len, CHARSET_INFO *cs,
     }
 }
 
-/* Verify that a phrase (sequence of words) appears in a document.
-   Tokenizes the document and checks for consecutive word matches. */
-static bool fts_verify_phrase(TABLE *table, const KEY *key_info, const uchar *record,
-                              CHARSET_INFO *cs, const std::vector<std::string> &phrase_words)
+/* Verify that a phrase appears as a consecutive subsequence within an
+   already-tokenized document.  Callers tokenize a candidate once and check
+   many phrases against the same token vector. */
+static bool fts_phrase_in_tokens(const std::vector<fts_token_t> &doc_tokens,
+                                 const std::vector<std::string> &phrase_words)
 {
     if (phrase_words.empty()) return true;
-
-    /* We extract and tokenize the full document text */
-    std::vector<fts_token_t> doc_tokens;
-    fts_extract_and_tokenize(table, key_info, record, cs, doc_tokens);
-
     if (doc_tokens.size() < phrase_words.size()) return false;
 
-    /* We scan for the phrase as a consecutive subsequence! */
     size_t limit = doc_tokens.size() - phrase_words.size();
     for (size_t i = 0; i <= limit; i++)
     {
@@ -1220,6 +1294,19 @@ static bool wkb_parse_geometry(const uchar *&pp, const uchar *ee, double &mn_x, 
                                double &mx_x, double &mx_y)
 {
     if (pp + SPATIAL_WKB_HEADER_SIZE > ee) return false;
+        /* MariaDB stores WKB in native byte order, so the leading byte is the
+           native endianness marker (0 = big, 1 = little).  We rely on native
+           order for the memcpy reads of the geometry type and coordinates
+           below; if MariaDB ever changed to store non-native WKB, this assert
+           would fire instead of silently returning garbage MBRs.  Release
+           builds simply trust the convention. */
+#ifndef DBUG_OFF
+    {
+        const uint32_t endian_probe = 1;
+        uchar native_byte_order = *(const uchar *)&endian_probe; /* 1 on LE, 0 on BE */
+        DBUG_ASSERT(*pp == native_byte_order);
+    }
+#endif
     pp++; /* we skip byte_order (MariaDB stores in native order) */
     uint32_t gt;
     memcpy(&gt, pp, 4);
@@ -1466,7 +1553,7 @@ static ulong srv_log_level = 0;                                      /* TDB_LOG_
 static ulonglong srv_block_cache_size = TIDESDB_DEFAULT_BLOCK_CACHE; /* 256M */
 static ulong srv_max_open_sstables = 256;
 static ulonglong srv_max_memory_usage = 0; /* 0 = auto (library decides) */
-static my_bool srv_log_to_file = 1;        /* write TidesDB logs to file (default: yes) */
+static my_bool srv_log_to_file = 1;        /* write TidesDB logs to file (default is yes) */
 static ulonglong srv_log_truncation_at = 24ULL * 1024 * 1024; /* log file truncation size (24MB) */
 static my_bool srv_unified_memtable = 1; /* 1 = unified WAL+memtable (default), 0 = per-CF */
 static ulonglong srv_unified_memtable_write_buffer_size = 128ULL * 1024 * 1024; /* 128MB */
@@ -1854,11 +1941,11 @@ static void tidesdb_promote_primary_update(THD *thd, struct st_mysql_sys_var *, 
     int rc = tidesdb_promote_to_primary(tdb_global);
     if (rc == TDB_SUCCESS)
     {
-        sql_print_information("TIDESDB: Replica promoted to primary successfully");
+        sql_print_information("[TIDESDB] Replica promoted to primary successfully");
     }
     else
     {
-        sql_print_error("TIDESDB: Failed to promote replica (err=%d)", rc);
+        sql_print_error("[TIDESDB] Failed to promote replica (err=%d)", rc);
     }
 
     /* reset to OFF so it can be triggered again */
@@ -1929,8 +2016,8 @@ static void tidesdb_backup_dir_update(THD *thd, struct st_mysql_sys_var *, void 
 
     if (rc != TDB_SUCCESS)
     {
-        sql_print_error("TIDESDB: Backup to '%s' failed (err=%d)", backup_path.c_str(), rc);
-        my_printf_error(ER_UNKNOWN_ERROR, "TIDESDB: Backup to '%s' failed (err=%d)", MYF(0),
+        sql_print_error("[TIDESDB] Backup to '%s' failed (err=%d)", backup_path.c_str(), rc);
+        my_printf_error(ER_UNKNOWN_ERROR, "[TIDESDB] Backup to '%s' failed (err=%d)", MYF(0),
                         backup_path.c_str(), rc);
         /* We leave variable unchanged on failure */
         return;
@@ -1974,8 +2061,8 @@ static void tidesdb_checkpoint_dir_update(THD *thd, struct st_mysql_sys_var *, v
 
     if (rc != TDB_SUCCESS)
     {
-        sql_print_error("TIDESDB: Checkpoint to '%s' failed (err=%d)", new_dir, rc);
-        my_printf_error(ER_UNKNOWN_ERROR, "TIDESDB: Checkpoint to '%s' failed (err=%d)", MYF(0),
+        sql_print_error("[TIDESDB] Checkpoint to '%s' failed (err=%d)", new_dir, rc);
+        my_printf_error(ER_UNKNOWN_ERROR, "[TIDESDB] Checkpoint to '%s' failed (err=%d)", MYF(0),
                         new_dir, rc);
         return;
     }
@@ -2298,6 +2385,8 @@ TidesDB_share::TidesDB_share()
       num_secondary_indexes(0)
 {
     memset(idx_comp_key_len, 0, sizeof(idx_comp_key_len));
+    memset(idx_is_fts, 0, sizeof(idx_is_fts));
+    memset(idx_is_spatial, 0, sizeof(idx_is_spatial));
     for (uint i = 0; i < MAX_KEY; i++) cached_rec_per_key[i].store(0, std::memory_order_relaxed);
 }
 
@@ -2341,7 +2430,14 @@ static tidesdb_trx_t *get_or_create_trx(THD *thd, handlerton *hton, tidesdb_isol
             int rrc = tidesdb_txn_reset(trx->txn, iso);
             if (rrc != TDB_SUCCESS)
             {
-                /* Reset failed -- we fall back to free + begin */
+                /* Reset failed -- we fall back to free + begin.  Surface the
+                   failure so we can spot regressions in txn recycling instead
+                   of silently degrading to per-statement free+begin. */
+                sql_print_warning(
+                    "[TIDESDB] tidesdb_txn_reset failed (rc=%d), falling back to "
+                    "free+begin -- expect higher per-statement overhead until "
+                    "this is investigated",
+                    rrc);
                 tidesdb_txn_free(trx->txn);
                 trx->txn = NULL;
                 int rc = tidesdb_txn_begin_with_isolation(tdb_global, iso, &trx->txn);
@@ -2373,16 +2469,21 @@ static tidesdb_trx_t *get_or_create_trx(THD *thd, handlerton *hton, tidesdb_isol
     trx->txn_generation = 1;
     trx->lock_txn_id = 1;
     trx->held_locks_head = NULL;
-    trx->waiting_on = NULL;
+    trx->waiting_on.store(NULL, std::memory_order_relaxed);
     thd_set_ha_data(thd, hton, trx);
     return trx;
 }
 
 /* ******************** Handlerton transaction callbacks ******************** */
 
+/* Maximum length of a TidesDB savepoint name, including the trailing NUL.
+   Names are synthesized by snprintf("sv_%p", sv); 32 bytes fits the
+   decoded pointer plus prefix on all supported platforms. */
+static constexpr uint TIDESDB_SAVEPOINT_NAME_MAX = 32;
+
 struct tidesdb_savepoint_t
 {
-    char name[32];
+    char name[TIDESDB_SAVEPOINT_NAME_MAX];
 };
 
 #if MYSQL_VERSION_ID >= 110800
@@ -2518,7 +2619,7 @@ static int tidesdb_commit(handlerton *, THD *thd, bool all)
             /* Only log truly unexpected errors (not transient conflicts). */
             if (rc != TDB_ERR_CONFLICT && rc != TDB_ERR_LOCKED && rc != TDB_ERR_MEMORY_LIMIT)
                 sql_print_error(
-                    "TIDESDB: hton_commit: tidesdb_txn_commit returned %d "
+                    "[TIDESDB] hton_commit: tidesdb_txn_commit returned %d "
                     "(dirty=%d gen=%lu)",
                     rc, trx->dirty, (unsigned long)trx->txn_generation);
             tidesdb_txn_rollback(trx->txn);
@@ -2661,7 +2762,11 @@ static bool tidesdb_show_status(handlerton *hton, THD *thd, stat_print_fn *print
     memset(&cache_st, 0, sizeof(cache_st));
     tidesdb_get_cache_stats(tdb_global, &cache_st);
 
-    char buf[8192];
+    /* Output buffer for SHOW ENGINE TIDESDB STATUS.  8 KiB is enough to
+       hold the fixed-format sections plus an optional object-store block
+       and the last-conflict line without truncating. */
+    static constexpr uint TIDESDB_STATUS_BUF_LEN = 8192;
+    char buf[TIDESDB_STATUS_BUF_LEN];
     int pos = 0;
 
     pos += snprintf(buf + pos, sizeof(buf) - pos,
@@ -2737,7 +2842,9 @@ static bool tidesdb_show_status(handlerton *hton, THD *thd, stat_print_fn *print
             snprintf(buf + pos, sizeof(buf) - pos, "\n--- Conflicts ---\n%s\n", last_conflict_info);
     mysql_mutex_unlock(&last_conflict_mutex);
 
-    return print(thd, "TIDESDB", 7, "", 0, buf, (size_t)pos);
+    static constexpr const char TIDESDB_ENGINE_NAME[] = "TIDESDB";
+    static constexpr uint TIDESDB_ENGINE_NAME_LEN = sizeof(TIDESDB_ENGINE_NAME) - 1;
+    return print(thd, TIDESDB_ENGINE_NAME, TIDESDB_ENGINE_NAME_LEN, "", 0, buf, (size_t)pos);
 }
 
 /* ******************** Schema discovery (object store mode) ******************** */
@@ -3127,7 +3234,7 @@ static void schema_cf_ensure_databases()
                 {
                     if (my_mkdir(db_dir, 0755, MYF(0)) == 0)
                         sql_print_information(
-                            "TIDESDB: Created database directory '%s' for schema discovery",
+                            "[TIDESDB] Created database directory '%s' for schema discovery",
                             dbname.c_str());
                 }
             }
@@ -3187,7 +3294,7 @@ static int tidesdb_init_func(void *p)
     /* Initialize FTS stop word set with defaults */
     mysql_rwlock_init(tdb_stopword_lock_key, &tdb_stopword_lock);
     tdb_load_default_stopwords();
-    sql_print_information("TIDESDB: Loaded %zu default stop words", tdb_stopwords.size());
+    sql_print_information("[TIDESDB] Loaded %zu default stop words", tdb_stopwords.size());
 
     /* Initialize FTS blend chars */
     mysql_rwlock_init(tdb_blend_lock_key, &tdb_blend_lock);
@@ -3242,7 +3349,7 @@ static int tidesdb_init_func(void *p)
         if (!srv_s3_endpoint || !srv_s3_bucket || !srv_s3_access_key || !srv_s3_secret_key)
         {
             sql_print_error(
-                "TIDESDB: S3 backend requires s3_endpoint, s3_bucket, "
+                "[TIDESDB] S3 backend requires s3_endpoint, s3_bucket, "
                 "s3_access_key, and s3_secret_key");
             DBUG_RETURN(1);
         }
@@ -3253,16 +3360,16 @@ static int tidesdb_init_func(void *p)
 
         if (!objstore_connector)
         {
-            sql_print_error("TIDESDB: Failed to create S3 connector for %s/%s", srv_s3_endpoint,
+            sql_print_error("[TIDESDB] Failed to create S3 connector for %s/%s", srv_s3_endpoint,
                             srv_s3_bucket);
             DBUG_RETURN(1);
         }
 
-        sql_print_information("TIDESDB: S3 connector created (endpoint=%s, bucket=%s, ssl=%s)",
+        sql_print_information("[TIDESDB] S3 connector created (endpoint=%s, bucket=%s, ssl=%s)",
                               srv_s3_endpoint, srv_s3_bucket, srv_s3_use_ssl ? "yes" : "no");
 #else
         sql_print_error(
-            "TIDESDB: S3 backend requested but TidesDB was not built with "
+            "[TIDESDB] S3 backend requested but TidesDB was not built with "
             "-DTIDESDB_WITH_S3=ON");
         DBUG_RETURN(1);
 #endif
@@ -3286,11 +3393,11 @@ static int tidesdb_init_func(void *p)
     int rc = tidesdb_open(&cfg, &tdb_global);
     if (rc != TDB_SUCCESS)
     {
-        sql_print_error("TIDESDB: Failed to open TidesDB at %s (err=%d)", tdb_path.c_str(), rc);
+        sql_print_error("[TIDESDB] Failed to open TidesDB at %s (err=%d)", tdb_path.c_str(), rc);
         DBUG_RETURN(1);
     }
 
-    sql_print_information("TIDESDB: TidesDB opened at %s", tdb_path.c_str());
+    sql_print_information("[TIDESDB] TidesDB opened at %s", tdb_path.c_str());
 
     /* Schema discovery CF -- created when object store is active so that
        replicas can discover table definitions from the shared storage. */
@@ -3312,7 +3419,7 @@ static int tidesdb_init_func(void *p)
                CF so MariaDB discovers them (relevant for replicas). */
             schema_cf_ensure_databases();
 
-            sql_print_information("TIDESDB: Schema discovery enabled (object store mode)");
+            sql_print_information("[TIDESDB] Schema discovery enabled (object store mode)");
         }
     }
 
@@ -3356,7 +3463,7 @@ static int tidesdb_deinit_func(void *p)
         lock_partitions = NULL;
     }
 
-    sql_print_information("TIDESDB: TidesDB closed");
+    sql_print_information("[TIDESDB] TidesDB closed");
     DBUG_RETURN(0);
 }
 
@@ -3419,6 +3526,17 @@ ha_tidesdb::ha_tidesdb(handlerton *hton, TABLE_SHARE *table_arg)
       cached_skip_unique_(false),
       cached_thdvars_valid_(false),
       stmt_has_write_lock_(false),
+      is_pk_(false),
+      scan_iter_last_err_(0),
+      scan_iter_last_err_cf_(NULL),
+      scan_iter_last_err_txn_(NULL),
+      has_blobs_(false),
+      encrypted_(false),
+      record1_lo_(NULL),
+      record1_hi_(NULL),
+      cached_sql_cmd_(0),
+      cached_is_autocommit_(false),
+      cached_stmt_shape_valid_(false),
       cached_thd_(NULL),
       cached_trx_(NULL),
       trx_registered_(false),
@@ -3661,26 +3779,22 @@ bool ha_tidesdb::try_keyread_from_index(const uint8_t *ik, size_t iks, uint idx,
     KEY *idx_key = &table->key_info[idx];
     uint idx_col_len = share->idx_comp_key_len[idx];
 
-    /* We check every column in read_set -- it must be a PK part or an
-       index part that decode_sort_key_part() can reverse-decode. */
-    for (uint c = bitmap_get_first_set(table->read_set); c != MY_BIT_NONE;
-         c = bitmap_get_next_set(table->read_set, c))
+    /* We check every column in read_set against the precomputed coverage
+       bitmap for this index.  O(read_set set-bits) instead of the prior
+       O(set-bits * (pk_parts + idx_parts)) nested scan. */
+    if (idx < share->idx_cover.size())
     {
-        bool found = false;
-        for (uint p = 0; p < pk_key->user_defined_key_parts; p++)
-            if ((uint)(pk_key->key_part[p].fieldnr - 1) == c)
-            {
-                found = true;
-                break;
-            }
-        if (!found)
-            for (uint p = 0; p < idx_key->user_defined_key_parts; p++)
-                if ((uint)(idx_key->key_part[p].fieldnr - 1) == c)
-                {
-                    found = true;
-                    break;
-                }
-        if (!found) return false;
+        const std::vector<bool> &cover = share->idx_cover[idx];
+        for (uint c = bitmap_get_first_set(table->read_set); c != MY_BIT_NONE;
+             c = bitmap_get_next_set(table->read_set, c))
+        {
+            if (c >= cover.size() || !cover[c]) return false;
+        }
+    }
+    else
+    {
+        /* Share not populated for this index (shouldn't happen). */
+        return false;
     }
 
     /* We decode index column parts from the head of the key */
@@ -3748,13 +3862,11 @@ bool ha_tidesdb::try_keyread_from_index(const uint8_t *ik, size_t iks, uint idx,
 
 /*
   Reverse a single integer sort-key part (big-endian, sign-bit-flipped)
-  back to native little-endian field format in the record buffer.
-  Returns true on success, false for unsupported field types.
+  back to native little-endian at `to`.  Caller precomputes `to` so we
+  don't re-walk f->ptr/f->table->record[0] on every decode.
 */
-bool ha_tidesdb::decode_int_sort_key(const uint8_t *src, uint sort_len, Field *f, uchar *buf)
+bool ha_tidesdb::decode_int_sort_key(const uint8_t *src, uint sort_len, bool is_signed, uchar *to)
 {
-    uchar *to = buf + (uintptr_t)(f->ptr - f->table->record[0]);
-    bool is_signed = !f->is_unsigned();
     switch (sort_len)
     {
         case 1:
@@ -3813,6 +3925,10 @@ bool ha_tidesdb::decode_int_sort_key(const uint8_t *src, uint sort_len, Field *f
 */
 bool ha_tidesdb::decode_sort_key_part(const uint8_t *src, uint sort_len, Field *f, uchar *buf)
 {
+    /* Compute the destination pointer exactly once per call.  Every branch
+       below wrote `buf + (f->ptr - f->table->record[0])` independently. */
+    uchar *to = buf + (uintptr_t)(f->ptr - f->table->record[0]);
+
     switch (f->real_type())
     {
         case MYSQL_TYPE_TINY:
@@ -3820,22 +3936,17 @@ bool ha_tidesdb::decode_sort_key_part(const uint8_t *src, uint sort_len, Field *
         case MYSQL_TYPE_INT24:
         case MYSQL_TYPE_LONG:
         case MYSQL_TYPE_LONGLONG:
-            return decode_int_sort_key(src, sort_len, f, buf);
+            return decode_int_sort_key(src, sort_len, !f->is_unsigned(), to);
 
         case MYSQL_TYPE_YEAR:
-        {
             /* YEAR is 1 byte unsigned, sort key is identity */
-            uchar *to = buf + (uintptr_t)(f->ptr - f->table->record[0]);
             to[0] = src[0];
             return true;
-        }
 
         case MYSQL_TYPE_DATE:
         case MYSQL_TYPE_NEWDATE:
-        {
             /* DATE is 3 bytes, sort key is big-endian unsigned.
                Reverse to native little-endian. */
-            uchar *to = buf + (uintptr_t)(f->ptr - f->table->record[0]);
             if (sort_len == 3)
             {
                 to[0] = src[2];
@@ -3844,32 +3955,26 @@ bool ha_tidesdb::decode_sort_key_part(const uint8_t *src, uint sort_len, Field *
                 return true;
             }
             return false;
-        }
 
         case MYSQL_TYPE_DATETIME:
         case MYSQL_TYPE_DATETIME2:
         case MYSQL_TYPE_TIMESTAMP:
         case MYSQL_TYPE_TIMESTAMP2:
-        {
             /* DATETIME/TIMESTAMP sort keys are big-endian unsigned.
                Reverse to native little-endian. */
-            uchar *to = buf + (uintptr_t)(f->ptr - f->table->record[0]);
             if (sort_len <= 8)
             {
                 for (uint b = 0; b < sort_len; b++) to[b] = src[sort_len - 1 - b];
                 return true;
             }
             return false;
-        }
 
         case MYSQL_TYPE_STRING:
-        {
             /* Fixed-length CHAR/BINARY.  For binary/latin1 charsets the
                sort key is identical to the stored content (space-padded).
                For multi-byte charsets we cannot reverse. */
             if (f->charset() == &my_charset_bin || f->charset() == &my_charset_latin1)
             {
-                uchar *to = buf + (uintptr_t)(f->ptr - f->table->record[0]);
                 uint flen = f->pack_length();
                 uint copy_len = (sort_len < flen) ? sort_len : flen;
                 memcpy(to, src, copy_len);
@@ -3877,7 +3982,6 @@ bool ha_tidesdb::decode_sort_key_part(const uint8_t *src, uint sort_len, Field *
                 return true;
             }
             return false;
-        }
 
         default:
             return false;
@@ -4092,7 +4196,7 @@ int ha_tidesdb::open(const char *name, int mode, uint test_if_locked)
         if (!share->cf)
         {
             unlock_shared_ha_data();
-            sql_print_error("TIDESDB: CF '%s' not found for table '%s'", share->cf_name.c_str(),
+            sql_print_error("[TIDESDB] CF '%s' not found for table '%s'", share->cf_name.c_str(),
                             name);
             DBUG_RETURN(HA_ERR_NO_SUCH_TABLE);
         }
@@ -4133,7 +4237,7 @@ int ha_tidesdb::open(const char *name, int mode, uint test_if_locked)
             uint ver = encryption_key_get_latest_version(share->encryption_key_id);
             if (ver == ENCRYPTION_KEY_VERSION_INVALID)
             {
-                sql_print_error("TIDESDB: encryption key %u not available",
+                sql_print_error("[TIDESDB] encryption key %u not available",
                                 share->encryption_key_id);
                 DBUG_RETURN(HA_ERR_NO_SUCH_TABLE);
             }
@@ -4150,21 +4254,53 @@ int ha_tidesdb::open(const char *name, int mode, uint test_if_locked)
             }
         }
 
-        /* We cache table shape flags for hot-path short-circuiting */
+        /* We cache table shape flags for hot-path short-circuiting.  We also
+           capture the BLOB field indices so serialize_row's size estimate can
+           iterate that short list instead of every field on every INSERT. */
         share->has_blobs = false;
+        share->blob_field_indices.clear();
         for (uint i = 0; i < table->s->fields; i++)
         {
             if (table->s->field[i]->flags & BLOB_FLAG)
             {
                 share->has_blobs = true;
-                break;
+                share->blob_field_indices.push_back((uint16)i);
             }
         }
         share->has_ttl = (share->default_ttl > 0 || share->ttl_field_idx >= 0);
 
-        /* We precompute comparable key lengths per index */
+        /* We precompute comparable key lengths and index-type flags per index.
+           Caching the type flags avoids a ki->algorithm dereference per row
+           in write_row's dup-check loop and in update_row/delete_row. */
         for (uint i = 0; i < table->s->keys; i++)
+        {
             share->idx_comp_key_len[i] = comparable_key_length(&table->key_info[i]);
+            share->idx_is_fts[i] = is_fts_index(&table->key_info[i]);
+            share->idx_is_spatial[i] = is_spatial_index(&table->key_info[i]);
+        }
+
+        /* Precompute per-index coverage bitmaps so try_keyread_from_index is
+           O(set bits in read_set) instead of nested scans over key parts. */
+        share->idx_cover.assign(table->s->keys, std::vector<bool>(table->s->fields, false));
+        for (uint i = 0; i < table->s->keys; i++)
+        {
+            const KEY *ki = &table->key_info[i];
+            for (uint p = 0; p < ki->user_defined_key_parts; p++)
+            {
+                uint fnr = ki->key_part[p].fieldnr;
+                if (fnr > 0 && fnr - 1 < table->s->fields) share->idx_cover[i][fnr - 1] = true;
+            }
+            /* Secondary indexes also cover the PK columns appended to the key. */
+            if (table->s->primary_key != MAX_KEY && i != table->s->primary_key)
+            {
+                const KEY *pk_key = &table->key_info[table->s->primary_key];
+                for (uint p = 0; p < pk_key->user_defined_key_parts; p++)
+                {
+                    uint fnr = pk_key->key_part[p].fieldnr;
+                    if (fnr > 0 && fnr - 1 < table->s->fields) share->idx_cover[i][fnr - 1] = true;
+                }
+            }
+        }
 
         /* We resolve secondary index CFs */
         for (uint i = 0; i < table->s->keys; i++)
@@ -4202,6 +4338,26 @@ int ha_tidesdb::open(const char *name, int mode, uint test_if_locked)
 
     /* We set ref_length for position()/rnd_pos() */
     ref_length = share->pk_key_len;
+
+    /* We mirror shape flags onto the handler so the row-fetch hot paths
+       read from a local member instead of chasing `share` into shared
+       memory on every row.  These mirror constants that never change for
+       the open handler. */
+    has_blobs_ = share->has_blobs;
+    encrypted_ = share->encrypted;
+
+    /* We precompute the record[1] pointer range so the BLOB path of
+       fetch_row_by_pk/iter_read_current doesn't rebuild it per row. */
+    if (table->record[1])
+    {
+        record1_lo_ = table->record[1];
+        record1_hi_ = table->record[1] + table->s->reclength;
+    }
+    else
+    {
+        record1_lo_ = NULL;
+        record1_hi_ = NULL;
+    }
 
     DBUG_RETURN(0);
 }
@@ -4242,7 +4398,7 @@ int ha_tidesdb::create(const char *name, TABLE *table_arg, HA_CREATE_INFO *creat
         int rc = tidesdb_create_column_family(tdb_global, cf_name.c_str(), &cfg);
         if (rc != TDB_SUCCESS)
         {
-            sql_print_error("TIDESDB: Failed to create CF '%s' (err=%d)", cf_name.c_str(), rc);
+            sql_print_error("[TIDESDB] Failed to create CF '%s' (err=%d)", cf_name.c_str(), rc);
             DBUG_RETURN(tdb_rc_to_ha(rc, "create main_cf"));
         }
     }
@@ -4263,7 +4419,7 @@ int ha_tidesdb::create(const char *name, TABLE *table_arg, HA_CREATE_INFO *creat
             int rc = tidesdb_create_column_family(tdb_global, idx_cf.c_str(), &idx_cfg);
             if (rc != TDB_SUCCESS)
             {
-                sql_print_error("TIDESDB: Failed to create index CF '%s' (err=%d)", idx_cf.c_str(),
+                sql_print_error("[TIDESDB] Failed to create index CF '%s' (err=%d)", idx_cf.c_str(),
                                 rc);
                 DBUG_RETURN(tdb_rc_to_ha(rc, "create idx_cf"));
             }
@@ -4309,7 +4465,7 @@ static bool tidesdb_encrypt_row_into(const std::string &plain, uint key_id, uint
                               TIDESDB_ENC_IV_LEN, ENCRYPTION_FLAG_ENCRYPT, key_id, key_version);
     if (rc != 0)
     {
-        sql_print_error("TIDESDB: encryption_crypt(encrypt) failed rc=%d", rc);
+        sql_print_error("[TIDESDB] encryption_crypt(encrypt) failed rc=%d", rc);
         out.clear();
         return false;
     }
@@ -4324,7 +4480,7 @@ static std::string tidesdb_decrypt_row(const char *data, size_t len, uint key_id
 {
     if (len <= TIDESDB_ENC_IV_LEN)
     {
-        sql_print_error("TIDESDB: encrypted row too short (%zu bytes)", len);
+        sql_print_error("[TIDESDB] encrypted row too short (%zu bytes)", len);
         return std::string(); /* signal failure */
     }
 
@@ -4344,7 +4500,7 @@ static std::string tidesdb_decrypt_row(const char *data, size_t len, uint key_id
                               TIDESDB_ENC_IV_LEN, ENCRYPTION_FLAG_DECRYPT, key_id, key_version);
     if (rc != 0)
     {
-        sql_print_error("TIDESDB: encryption_crypt(decrypt) failed rc=%d", rc);
+        sql_print_error("[TIDESDB] encryption_crypt(decrypt) failed rc=%d", rc);
         return std::string(); /* signal failure */
     }
     out.resize(dlen);
@@ -4377,10 +4533,11 @@ const std::string &ha_tidesdb::serialize_row(const uchar *buf)
     }
     if (share->has_blobs)
     {
-        for (uint i = 0; i < table->s->fields; i++)
+        /* Walk only the precomputed BLOB field list instead of every field. */
+        for (uint16 idx : share->blob_field_indices)
         {
-            Field *f = table->field[i];
-            if (!(f->flags & BLOB_FLAG) || f->is_real_null(ptrdiff)) continue;
+            Field *f = table->field[idx];
+            if (f->is_real_null(ptrdiff)) continue;
             Field_blob *blob = (Field_blob *)f;
             est += blob->get_length(buf + (uintptr_t)(f->ptr - table->record[0]));
         }
@@ -4555,7 +4712,7 @@ void ha_tidesdb::deserialize_row(uchar *buf, const std::string &row)
 */
 int ha_tidesdb::fetch_row_by_pk(tidesdb_txn_t *txn, const uchar *pk, uint pk_len, uchar *buf)
 {
-    uchar dk[MAX_KEY_LENGTH + 2];
+    uchar dk[DATA_KEY_BUF_LEN];
     uint dk_len = build_data_key(pk, pk_len, dk);
 
     uint8_t *value = NULL;
@@ -4564,7 +4721,7 @@ int ha_tidesdb::fetch_row_by_pk(tidesdb_txn_t *txn, const uchar *pk, uint pk_len
     if (rc == TDB_ERR_NOT_FOUND) return HA_ERR_KEY_NOT_FOUND;
     if (rc != TDB_SUCCESS) return tdb_rc_to_ha(rc, "fetch_row_by_pk");
 
-    if (likely(!share->has_blobs && !share->encrypted))
+    if (likely(!has_blobs_ && !encrypted_))
     {
         /* Zero-copy path, we deserialize directly from API buffer */
         deserialize_row(buf, (const uchar *)value, value_size);
@@ -4581,10 +4738,8 @@ int ha_tidesdb::fetch_row_by_pk(tidesdb_txn_t *txn, const uchar *pk, uint pk_len
            This prevents a fetch into record[1] from invalidating BLOB
            pointers that record[0] still references.
 
-           We identify record[1] by checking whether buf falls within the
-           record[1] memory region (table->record[1] .. +share->reclength). */
-        bool is_rec1 = table->record[1] && buf >= table->record[1] &&
-                       buf < table->record[1] + table->s->reclength;
+           We identify record[1] using the precomputed bounds set in open(). */
+        bool is_rec1 = record1_lo_ && buf >= record1_lo_ && buf < record1_hi_;
         std::string &backing = is_rec1 ? last_row2 : last_row;
         backing.assign((const char *)value, value_size);
         tidesdb_free(value);
@@ -4671,14 +4826,13 @@ int ha_tidesdb::iter_read_current(uchar *buf)
         current_pk_len_ = (uint)(key_size - 1);
         memcpy(current_pk_buf_, key + 1, current_pk_len_);
 
-        if (likely(!share->has_blobs && !share->encrypted))
+        if (likely(!has_blobs_ && !encrypted_))
         {
             deserialize_row(buf, (const uchar *)value, value_size);
         }
         else
         {
-            bool is_rec1 = table->record[1] && buf >= table->record[1] &&
-                           buf < table->record[1] + table->s->reclength;
+            bool is_rec1 = record1_lo_ && buf >= record1_lo_ && buf < record1_hi_;
             std::string &backing = is_rec1 ? last_row2 : last_row;
             backing.assign((const char *)value, value_size);
             deserialize_row(buf, backing);
@@ -4742,14 +4896,14 @@ int ha_tidesdb::write_row(const uchar *buf)
         pk_len = HIDDEN_PK_SIZE;
     }
 
-    uchar dk[MAX_KEY_LENGTH + 2];
+    uchar dk[DATA_KEY_BUF_LEN];
     uint dk_len = build_data_key(pk, pk_len, dk);
 
     const std::string &row_data = serialize_row(buf);
     if (share->encrypted && row_data.empty())
     {
         tmp_restore_column_map(&table->read_set, old_map);
-        sql_print_error("TIDESDB: write_row encryption failed");
+        sql_print_error("[TIDESDB] write_row encryption failed");
         DBUG_RETURN(HA_ERR_GENERIC);
     }
     const uint8_t *row_ptr = (const uint8_t *)row_data.data();
@@ -4845,8 +4999,7 @@ int ha_tidesdb::write_row(const uchar *buf)
         {
             if (share->has_user_pk && i == share->pk_index) continue;
             if (i >= share->idx_cfs.size() || !share->idx_cfs[i]) continue;
-            if (is_fts_index(&table->key_info[i])) continue;
-            if (is_spatial_index(&table->key_info[i])) continue;
+            if (share->idx_is_fts[i] || share->idx_is_spatial[i]) continue;
             if (!(table->key_info[i].flags & HA_NOSAME)) continue;
 
             uchar idx_prefix[MAX_KEY_LENGTH];
@@ -4945,11 +5098,12 @@ int ha_tidesdb::write_row(const uchar *buf)
 
                 for (auto &[term, tf] : tf_map)
                 {
-                    uchar fk[2 + 512 + MAX_KEY_LENGTH];
+                    uchar fk[FTS_KEY_BUF_LEN];
                     uint fk_len = fts_build_key(term.data(), (uint)term.size(), pk, pk_len, fk);
-                    uchar fv[6];
+                    uchar fv[FTS_VALUE_LEN];
                     fts_build_value(tf, word_count, fv);
-                    rc = tidesdb_txn_put(txn, share->idx_cfs[i], fk, fk_len, fv, 6, row_ttl);
+                    rc = tidesdb_txn_put(txn, share->idx_cfs[i], fk, fk_len, fv, FTS_VALUE_LEN,
+                                         row_ttl);
                     if (rc != TDB_SUCCESS) goto err;
                 }
 
@@ -4984,7 +5138,7 @@ int ha_tidesdb::write_row(const uchar *buf)
             else
             {
                 /* Regular secondary index maintenance */
-                uchar ik[MAX_KEY_LENGTH * 2 + 2];
+                uchar ik[SEC_IDX_KEY_BUF_LEN];
                 uint ik_len = sec_idx_key(i, buf, ik);
                 rc =
                     tidesdb_txn_put(txn, share->idx_cfs[i], ik, ik_len, &tdb_empty_val, 1, row_ttl);
@@ -5007,7 +5161,7 @@ int ha_tidesdb::write_row(const uchar *buf)
             {
                 int crc = tidesdb_txn_commit(trx->txn);
                 if (crc != TDB_SUCCESS)
-                    sql_print_information("TIDESDB: bulk insert mid-commit failed rc=%d", crc);
+                    sql_print_information("[TIDESDB] bulk insert mid-commit failed rc=%d", crc);
                 /* Reset reuses the txn with READ_COMMITTED -- bulk inserts
                    don't need snapshot consistency across batches and higher
                    levels would cause unbounded read-set growth. */
@@ -5015,6 +5169,10 @@ int ha_tidesdb::write_row(const uchar *buf)
                 if (rrc != TDB_SUCCESS)
                 {
                     /* Reset failed -- we fall back to free+recreate */
+                    sql_print_warning(
+                        "[TIDESDB] bulk_insert tidesdb_txn_reset failed (rc=%d), "
+                        "falling back to free+begin",
+                        rrc);
                     tidesdb_txn_free(trx->txn);
                     trx->txn = NULL;
                     crc = tidesdb_txn_begin_with_isolation(tdb_global, TDB_ISOLATION_READ_COMMITTED,
@@ -5195,6 +5353,9 @@ int ha_tidesdb::index_init(uint idx, bool sorted)
     idx_pk_exact_done_ = false;
     scan_dir_ = DIR_NONE;
     spatial_scan_active_ = false;
+    /* Cache is_pk for the duration of the scan so navigation methods can
+       read a member instead of re-deriving the answer per row. */
+    is_pk_ = share->has_user_pk && idx == share->pk_index;
 
     {
         int erc = ensure_stmt_txn();
@@ -5212,7 +5373,7 @@ int ha_tidesdb::index_init(uint idx, bool sorted)
     {
         scan_txn = NULL;
         scan_cf_ = NULL;
-        sql_print_error("TIDESDB: index_init: no CF for index %u", idx);
+        sql_print_error("[TIDESDB] index_init: no CF for index %u", idx);
         DBUG_RETURN(HA_ERR_GENERIC);
     }
 
@@ -5253,9 +5414,21 @@ int ha_tidesdb::index_init(uint idx, bool sorted)
 int ha_tidesdb::ensure_scan_iter()
 {
     if (scan_iter) return 0;
+
+    /* If a prior attempt with this exact (scan_cf_, scan_txn) combination
+       already failed, short-circuit instead of re-logging and re-failing.
+       The cache is invalidated whenever the caller changes scan_cf_ or
+       scan_txn (natural since those moves imply a new attempt). */
+    if (scan_iter_last_err_ && scan_iter_last_err_cf_ == scan_cf_ &&
+        scan_iter_last_err_txn_ == scan_txn)
+        return scan_iter_last_err_;
+
     if (!scan_txn || !scan_cf_)
     {
-        sql_print_error("TIDESDB: ensure_scan_iter: no txn or CF");
+        sql_print_error("[TIDESDB] ensure_scan_iter: no txn or CF");
+        scan_iter_last_err_ = HA_ERR_GENERIC;
+        scan_iter_last_err_cf_ = scan_cf_;
+        scan_iter_last_err_txn_ = scan_txn;
         return HA_ERR_GENERIC;
     }
     int rc = tidesdb_iter_new(scan_txn, scan_cf_, &scan_iter);
@@ -5264,9 +5437,14 @@ int ha_tidesdb::ensure_scan_iter()
         scan_iter_cf_ = scan_cf_;
         scan_iter_txn_ = scan_txn;
         scan_iter_txn_gen_ = cached_trx_ ? cached_trx_->txn_generation : 0;
+        scan_iter_last_err_ = 0;
         return 0;
     }
-    return tdb_rc_to_ha(rc, "ensure_scan_iter");
+    int herr = tdb_rc_to_ha(rc, "ensure_scan_iter");
+    scan_iter_last_err_ = herr;
+    scan_iter_last_err_cf_ = scan_cf_;
+    scan_iter_last_err_txn_ = scan_txn;
+    return herr;
 }
 
 int ha_tidesdb::index_end()
@@ -5301,12 +5479,10 @@ int ha_tidesdb::index_read_map(uchar *buf, const uchar *key, key_part_map keypar
     memcpy(idx_search_comp_, comp_key, comp_len);
     idx_search_comp_len_ = comp_len;
 
-    bool is_pk = share->has_user_pk && active_index == share->pk_index;
-
-    if (is_pk)
+    if (is_pk_)
     {
         /* We build the full data key -- KEY_NS_DATA + comparable_pk_bytes */
-        uchar seek_key[MAX_KEY_LENGTH + 2];
+        uchar seek_key[DATA_KEY_BUF_LEN];
         uint seek_len = build_data_key(comp_key, comp_len, seek_key);
 
         if (find_flag == HA_READ_KEY_EXACT)
@@ -5474,7 +5650,7 @@ int ha_tidesdb::index_read_map(uchar *buf, const uchar *key, key_part_map keypar
                  find_flag == HA_READ_PREFIX_LAST || find_flag == HA_READ_PREFIX_LAST_OR_PREV)
         {
             /* We build upper bound, comp_key with all 0xFF appended for pk portion */
-            uchar upper[MAX_KEY_LENGTH * 2 + 2];
+            uchar upper[SEC_IDX_KEY_BUF_LEN];
             memcpy(upper, comp_key, comp_len);
             memset(upper + comp_len, 0xFF, share->pk_key_len);
             uint upper_len = comp_len + share->pk_key_len;
@@ -5554,14 +5730,12 @@ int ha_tidesdb::index_next(uchar *buf)
         DBUG_RETURN(spatial_scan_next(buf));
     }
 
-    bool is_pk = share->has_user_pk && active_index == share->pk_index;
-
     if (idx_pk_exact_done_)
     {
         idx_pk_exact_done_ = false;
         int irc = ensure_scan_iter();
         if (irc) DBUG_RETURN(irc);
-        uchar seek_key[MAX_KEY_LENGTH + 2];
+        uchar seek_key[DATA_KEY_BUF_LEN];
         uint seek_len = build_data_key(current_pk_buf_, current_pk_len_, seek_key);
         tidesdb_iter_seek(scan_iter, seek_key, seek_len);
         if (tidesdb_iter_valid(scan_iter)) tidesdb_iter_next(scan_iter);
@@ -5578,7 +5752,7 @@ int ha_tidesdb::index_next(uchar *buf)
         if (scan_dir_ != DIR_NONE) tidesdb_iter_next(scan_iter);
     }
 
-    if (is_pk)
+    if (is_pk_)
     {
         int ret = iter_read_current(buf);
         scan_dir_ = DIR_FORWARD;
@@ -5632,7 +5806,7 @@ int ha_tidesdb::index_prev(uchar *buf)
         idx_pk_exact_done_ = false;
         int irc = ensure_scan_iter();
         if (irc) DBUG_RETURN(irc);
-        uchar seek_key[MAX_KEY_LENGTH + 2];
+        uchar seek_key[DATA_KEY_BUF_LEN];
         uint seek_len = build_data_key(current_pk_buf_, current_pk_len_, seek_key);
         tidesdb_iter_seek(scan_iter, seek_key, seek_len);
         /* iterator is at the matched key -- fall through to prev() */
@@ -5646,8 +5820,7 @@ int ha_tidesdb::index_prev(uchar *buf)
     /* We advance backward past the last-read entry */
     tidesdb_iter_prev(scan_iter);
 
-    bool is_pk = share->has_user_pk && active_index == share->pk_index;
-    if (is_pk)
+    if (is_pk_)
     {
         /* We skip meta keys going backwards */
         while (tidesdb_iter_valid(scan_iter))
@@ -5706,8 +5879,7 @@ int ha_tidesdb::index_first(uchar *buf)
     int irc = ensure_scan_iter();
     if (irc) DBUG_RETURN(irc);
 
-    bool is_pk = share->has_user_pk && active_index == share->pk_index;
-    if (is_pk)
+    if (is_pk_)
     {
         /* We seek to first data key */
         uint8_t data_prefix = KEY_NS_DATA;
@@ -5732,8 +5904,7 @@ int ha_tidesdb::index_last(uchar *buf)
     int irc = ensure_scan_iter();
     if (irc) DBUG_RETURN(irc);
 
-    bool is_pk = share->has_user_pk && active_index == share->pk_index;
-    if (is_pk)
+    if (is_pk_)
     {
         tidesdb_iter_seek_to_last(scan_iter);
         /* The last key might be a data key already, but skip backwards
@@ -5779,9 +5950,7 @@ int ha_tidesdb::index_next_same(uchar *buf, const uchar *key, uint keylen)
         DBUG_RETURN(spatial_scan_next(buf));
     }
 
-    bool is_pk = share->has_user_pk && active_index == share->pk_index;
-
-    if (is_pk)
+    if (is_pk_)
     {
         uint full_pk_comp_len = share->idx_comp_key_len[share->pk_index];
         if (idx_search_comp_len_ >= full_pk_comp_len)
@@ -5886,7 +6055,7 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
     if (share->encrypted && new_row.empty())
     {
         tmp_restore_column_map(&table->read_set, old_map);
-        sql_print_error("TIDESDB: update_row encryption failed");
+        sql_print_error("[TIDESDB] update_row encryption failed");
         DBUG_RETURN(HA_ERR_GENERIC);
     }
     const uint8_t *row_ptr = (const uint8_t *)new_row.data();
@@ -5927,175 +6096,236 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
     /* If PK changed, we delete old entry and insert new */
     if (pk_changed)
     {
-        uchar old_dk[MAX_KEY_LENGTH + 2];
+        uchar old_dk[DATA_KEY_BUF_LEN];
         uint old_dk_len = build_data_key(old_pk, old_pk_len, old_dk);
         rc = tidesdb_txn_delete(txn, share->cf, old_dk, old_dk_len);
         if (rc != TDB_SUCCESS) goto err;
     }
 
     {
-        uchar new_dk[MAX_KEY_LENGTH + 2];
+        uchar new_dk[DATA_KEY_BUF_LEN];
         uint new_dk_len = build_data_key(new_pk, new_pk_len, new_dk);
         rc = tidesdb_txn_put(txn, share->cf, new_dk, new_dk_len, row_ptr, row_len, row_ttl);
         if (rc != TDB_SUCCESS) goto err;
     }
 
-    /* We update secondary indexes -- we skip unchanged entries to avoid
-       redundant txn_delete + txn_put pairs. */
+    /* We update secondary indexes in a single consolidated dispatch loop.
+       Regular, FTS, and spatial indexes are handled inline, eliminating the
+       three separate passes over table->s->keys that the old code used.
+       Each branch short-circuits via a write_set pre-check so unchanged
+       indexes skip both key construction and LSM writes. */
     if (share->num_secondary_indexes > 0)
     {
         /* We use handler-owned buffers to avoid per-row heap allocation
            and keep the stack frame within -Wframe-larger-than limits. */
         uchar *old_ik = upd_old_ik_;
         uchar *new_ik = upd_new_ik_;
-        for (uint i = 0; i < table->s->keys; i++)
-        {
-            if (share->has_user_pk && i == share->pk_index) continue;
-            if (i >= share->idx_cfs.size() || !share->idx_cfs[i]) continue;
-            if (is_fts_index(&table->key_info[i])) continue;
-            if (is_spatial_index(&table->key_info[i])) continue;
+        const uint num_keys = table->s->keys;
+        const bool has_user_pk = share->has_user_pk;
+        const uint pk_index = share->pk_index;
+        const size_t idx_cfs_sz = share->idx_cfs.size();
 
-            /* We build old index entry key */
+        for (uint i = 0; i < num_keys; i++)
+        {
+            if (has_user_pk && i == pk_index) continue;
+            if (i >= idx_cfs_sz || !share->idx_cfs[i]) continue;
+
             KEY *ki = &table->key_info[i];
-            memcpy(current_pk_buf_, old_pk, old_pk_len);
-            current_pk_len_ = old_pk_len;
-            uint old_ik_len = make_comparable_key(ki, old_data, ki->user_defined_key_parts, old_ik);
-            memcpy(old_ik + old_ik_len, old_pk, old_pk_len);
-            old_ik_len += old_pk_len;
 
-            /* We build new index entry key */
-            memcpy(current_pk_buf_, new_pk, new_pk_len);
-            current_pk_len_ = new_pk_len;
-            uint new_ik_len = sec_idx_key(i, new_data, new_ik);
-
-            /* We skip if the index key is identical (indexed columns + PK unchanged) */
-            if (old_ik_len == new_ik_len && memcmp(old_ik, new_ik, old_ik_len) == 0) continue;
-
-            rc = tidesdb_txn_delete(txn, share->idx_cfs[i], old_ik, old_ik_len);
-            if (rc != TDB_SUCCESS) goto err;
-            rc = tidesdb_txn_put(txn, share->idx_cfs[i], new_ik, new_ik_len, &tdb_empty_val, 1,
-                                 row_ttl);
-            if (rc != TDB_SUCCESS) goto err;
-        }
-    }
-
-    /* We update FULLTEXT indexes, deleting old entries, insert new */
-    if (share->num_secondary_indexes > 0)
-    {
-        for (uint i = 0; i < table->s->keys; i++)
-        {
-            if (share->has_user_pk && i == share->pk_index) continue;
-            if (i >= share->idx_cfs.size() || !share->idx_cfs[i]) continue;
-            if (!is_fts_index(&table->key_info[i])) continue;
-
-            /* Check if any FTS column actually changed */
-            bool fts_changed = false;
-            for (uint p = 0; p < table->key_info[i].user_defined_key_parts; p++)
+            if (share->idx_is_fts[i])
             {
-                uint fieldnr = table->key_info[i].key_part[p].fieldnr - 1;
-                if (bitmap_is_set(table->write_set, fieldnr))
+                /* We skip if no indexed column actually changed */
+                bool fts_changed = false;
+                for (uint p = 0; p < ki->user_defined_key_parts; p++)
                 {
-                    fts_changed = true;
-                    break;
+                    uint fieldnr = ki->key_part[p].fieldnr - 1;
+                    if (bitmap_is_set(table->write_set, fieldnr))
+                    {
+                        fts_changed = true;
+                        break;
+                    }
                 }
-            }
-            if (!fts_changed) continue;
+                if (!fts_changed) continue;
 
-            CHARSET_INFO *fts_cs = table->key_info[i].key_part[0].field->charset();
+                CHARSET_INFO *fts_cs = ki->key_part[0].field->charset();
 
-            /* We delete old FTS entries */
-            {
-                std::vector<fts_token_t> old_tokens;
-                fts_extract_and_tokenize(table, &table->key_info[i], old_data, fts_cs, old_tokens);
-                std::unordered_map<std::string, uint16> old_tf;
+                /* Tokenize both old and new docs, build term-frequency maps,
+                   then emit only the minimum set of deletes/puts needed.
+                   For a small edit to a large document this avoids rewriting
+                   every term entry. */
+                std::vector<fts_token_t> old_tokens, new_tokens;
+                fts_extract_and_tokenize(table, ki, old_data, fts_cs, old_tokens);
+                fts_extract_and_tokenize(table, ki, new_data, fts_cs, new_tokens);
+
+                std::unordered_map<std::string, uint16> old_tf, new_tf;
                 for (auto &tok : old_tokens) old_tf[tok.word]++;
-                uint32 old_wc = (uint32)old_tokens.size();
-
-                for (auto &[term, tf] : old_tf)
-                {
-                    uchar fk[2 + 512 + MAX_KEY_LENGTH];
-                    uint fk_len =
-                        fts_build_key(term.data(), (uint)term.size(), old_pk, old_pk_len, fk);
-                    tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
-                }
-                fts_update_meta(txn, share->cf, i, -1, -(int64_t)old_wc);
-            }
-
-            /* We insert new FTS entries */
-            {
-                std::vector<fts_token_t> new_tokens;
-                fts_extract_and_tokenize(table, &table->key_info[i], new_data, fts_cs, new_tokens);
-                std::unordered_map<std::string, uint16> new_tf;
                 for (auto &tok : new_tokens) new_tf[tok.word]++;
+                uint32 old_wc = (uint32)old_tokens.size();
                 uint32 new_wc = (uint32)new_tokens.size();
 
-                for (auto &[term, tf] : new_tf)
+                if (pk_changed)
                 {
-                    uchar fk[2 + 512 + MAX_KEY_LENGTH];
-                    uint fk_len =
-                        fts_build_key(term.data(), (uint)term.size(), new_pk, new_pk_len, fk);
-                    uchar fv[6];
-                    fts_build_value(tf, new_wc, fv);
-                    rc = tidesdb_txn_put(txn, share->idx_cfs[i], fk, fk_len, fv, 6, row_ttl);
-                    if (rc != TDB_SUCCESS) goto err;
+                    /* PK changed -- the row identity changed so every old
+                       (term, old_pk) must be deleted and every new (term, new_pk)
+                       inserted.  No diffing possible across different PKs. */
+                    for (auto &[term, tf] : old_tf)
+                    {
+                        uchar fk[FTS_KEY_BUF_LEN];
+                        uint fk_len =
+                            fts_build_key(term.data(), (uint)term.size(), old_pk, old_pk_len, fk);
+                        tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
+                    }
+                    for (auto &[term, tf] : new_tf)
+                    {
+                        uchar fk[FTS_KEY_BUF_LEN];
+                        uint fk_len =
+                            fts_build_key(term.data(), (uint)term.size(), new_pk, new_pk_len, fk);
+                        uchar fv[FTS_VALUE_LEN];
+                        fts_build_value(tf, new_wc, fv);
+                        rc = tidesdb_txn_put(txn, share->idx_cfs[i], fk, fk_len, fv, FTS_VALUE_LEN,
+                                             row_ttl);
+                        if (rc != TDB_SUCCESS) goto err;
+                    }
                 }
-                fts_update_meta(txn, share->cf, i, +1, (int64_t)new_wc);
+                else
+                {
+                    /* PK stable -- apply term-level diff.  Only delete a term
+                       when it disappears and only write a term when it is new,
+                       its tf changes, or doc_len changes (doc_len is part of
+                       the stored value used by BM25). */
+                    bool doc_len_changed = (old_wc != new_wc);
+
+                    for (auto &[term, old_cnt] : old_tf)
+                    {
+                        if (new_tf.find(term) != new_tf.end()) continue;
+                        uchar fk[FTS_KEY_BUF_LEN];
+                        uint fk_len =
+                            fts_build_key(term.data(), (uint)term.size(), old_pk, old_pk_len, fk);
+                        tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
+                    }
+
+                    for (auto &[term, new_cnt] : new_tf)
+                    {
+                        auto it = old_tf.find(term);
+                        bool need_put;
+                        if (it == old_tf.end())
+                            need_put = true;
+                        else if (doc_len_changed)
+                            need_put = true;
+                        else
+                            need_put = (it->second != new_cnt);
+
+                        if (!need_put) continue;
+
+                        uchar fk[FTS_KEY_BUF_LEN];
+                        uint fk_len =
+                            fts_build_key(term.data(), (uint)term.size(), new_pk, new_pk_len, fk);
+                        uchar fv[FTS_VALUE_LEN];
+                        fts_build_value(new_cnt, new_wc, fv);
+                        rc = tidesdb_txn_put(txn, share->idx_cfs[i], fk, fk_len, fv, FTS_VALUE_LEN,
+                                             row_ttl);
+                        if (rc != TDB_SUCCESS) goto err;
+                    }
+                }
+
+                /* Meta: same doc stays, so delta_docs=0.  Word count shifts by
+                   new_wc - old_wc; only write the meta row when it actually
+                   moved to avoid a pointless read-modify-write. */
+                int64_t wc_delta = (int64_t)new_wc - (int64_t)old_wc;
+                if (wc_delta != 0) fts_update_meta(txn, share->cf, i, 0, wc_delta);
             }
-        }
-    }
-
-    /* We update SPATIAL indexes, same deal.. delete old entry, insert new */
-    if (share->num_secondary_indexes > 0)
-    {
-        for (uint i = 0; i < table->s->keys; i++)
-        {
-            if (share->has_user_pk && i == share->pk_index) continue;
-            if (i >= share->idx_cfs.size() || !share->idx_cfs[i]) continue;
-            if (!is_spatial_index(&table->key_info[i])) continue;
-
-            uint fieldnr = table->key_info[i].key_part[0].fieldnr - 1;
-            if (!bitmap_is_set(table->write_set, fieldnr)) continue;
-
-            Field *geom_field = table->key_info[i].key_part[0].field;
-
-            /* We delete old spatial entry */
+            else if (share->idx_is_spatial[i])
             {
-                my_ptrdiff_t ptd = (my_ptrdiff_t)(old_data - table->record[0]);
-                geom_field->move_field_offset(ptd);
-                String gs;
-                geom_field->val_str(&gs, &gs);
-                geom_field->move_field_offset(-ptd);
-                double xmn, ymn, xmx, ymx;
-                if (gs.length() > 0 && spatial_compute_mbr((const uchar *)gs.ptr(), gs.length(),
-                                                           &xmn, &ymn, &xmx, &ymx))
+                /* Spatial we skip if geometry column unchanged */
+                uint fieldnr = ki->key_part[0].fieldnr - 1;
+                if (!bitmap_is_set(table->write_set, fieldnr)) continue;
+
+                Field *geom_field = ki->key_part[0].field;
+
+                /* Delete old spatial entry */
                 {
-                    uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
-                    uint sk_len = spatial_build_key((xmn + xmx) / 2.0, (ymn + ymx) / 2.0, old_pk,
-                                                    old_pk_len, sk);
-                    tidesdb_txn_delete(txn, share->idx_cfs[i], sk, sk_len);
+                    my_ptrdiff_t ptd = (my_ptrdiff_t)(old_data - table->record[0]);
+                    geom_field->move_field_offset(ptd);
+                    String gs;
+                    geom_field->val_str(&gs, &gs);
+                    geom_field->move_field_offset(-ptd);
+                    double xmn, ymn, xmx, ymx;
+                    if (gs.length() > 0 && spatial_compute_mbr((const uchar *)gs.ptr(), gs.length(),
+                                                               &xmn, &ymn, &xmx, &ymx))
+                    {
+                        uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
+                        uint sk_len = spatial_build_key((xmn + xmx) / 2.0, (ymn + ymx) / 2.0,
+                                                        old_pk, old_pk_len, sk);
+                        tidesdb_txn_delete(txn, share->idx_cfs[i], sk, sk_len);
+                    }
+                }
+
+                /* Insert new spatial entry */
+                {
+                    my_ptrdiff_t ptd = (my_ptrdiff_t)(new_data - table->record[0]);
+                    geom_field->move_field_offset(ptd);
+                    String gs;
+                    geom_field->val_str(&gs, &gs);
+                    geom_field->move_field_offset(-ptd);
+                    double xmn, ymn, xmx, ymx;
+                    if (gs.length() > 0 && spatial_compute_mbr((const uchar *)gs.ptr(), gs.length(),
+                                                               &xmn, &ymn, &xmx, &ymx))
+                    {
+                        uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
+                        uint sk_len = spatial_build_key((xmn + xmx) / 2.0, (ymn + ymx) / 2.0,
+                                                        new_pk, new_pk_len, sk);
+                        uchar sv[SPATIAL_MBR_VALUE_LEN];
+                        spatial_build_value(xmn, ymn, xmx, ymx, sv);
+                        rc = tidesdb_txn_put(txn, share->idx_cfs[i], sk, sk_len, sv,
+                                             SPATIAL_MBR_VALUE_LEN, row_ttl);
+                        if (rc != TDB_SUCCESS) goto err;
+                    }
                 }
             }
-
-            /* We insert new spatial entry */
+            else
             {
-                my_ptrdiff_t ptd = (my_ptrdiff_t)(new_data - table->record[0]);
-                geom_field->move_field_offset(ptd);
-                String gs;
-                geom_field->val_str(&gs, &gs);
-                geom_field->move_field_offset(-ptd);
-                double xmn, ymn, xmx, ymx;
-                if (gs.length() > 0 && spatial_compute_mbr((const uchar *)gs.ptr(), gs.length(),
-                                                           &xmn, &ymn, &xmx, &ymx))
+                /* Regular secondary index we skip before building keys when no
+                   indexed column changed and the PK is stable.  Saves the
+                   per-row make_comparable_key/sec_idx_key cost on wide updates
+                   that touch only unrelated columns. */
+                if (!pk_changed)
                 {
-                    uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
-                    uint sk_len = spatial_build_key((xmn + xmx) / 2.0, (ymn + ymx) / 2.0, new_pk,
-                                                    new_pk_len, sk);
-                    uchar sv[SPATIAL_MBR_VALUE_LEN];
-                    spatial_build_value(xmn, ymn, xmx, ymx, sv);
-                    rc = tidesdb_txn_put(txn, share->idx_cfs[i], sk, sk_len, sv,
-                                         SPATIAL_MBR_VALUE_LEN, row_ttl);
-                    if (rc != TDB_SUCCESS) goto err;
+                    bool idx_changed = false;
+                    for (uint p = 0; p < ki->user_defined_key_parts; p++)
+                    {
+                        uint fieldnr = ki->key_part[p].fieldnr - 1;
+                        if (bitmap_is_set(table->write_set, fieldnr))
+                        {
+                            idx_changed = true;
+                            break;
+                        }
+                    }
+                    if (!idx_changed) continue;
                 }
+
+                /* Build old index entry key.  current_pk_buf_ is transiently
+                   set to old/new PK so sec_idx_key's pk_from_record path works
+                   for hidden-PK tables. */
+                memcpy(current_pk_buf_, old_pk, old_pk_len);
+                current_pk_len_ = old_pk_len;
+                uint old_ik_len =
+                    make_comparable_key(ki, old_data, ki->user_defined_key_parts, old_ik);
+                memcpy(old_ik + old_ik_len, old_pk, old_pk_len);
+                old_ik_len += old_pk_len;
+
+                /* Build new index entry key */
+                memcpy(current_pk_buf_, new_pk, new_pk_len);
+                current_pk_len_ = new_pk_len;
+                uint new_ik_len = sec_idx_key(i, new_data, new_ik);
+
+                /* Skip if the final index bytes match (e.g. UPDATE x=x). */
+                if (old_ik_len == new_ik_len && memcmp(old_ik, new_ik, old_ik_len) == 0) continue;
+
+                rc = tidesdb_txn_delete(txn, share->idx_cfs[i], old_ik, old_ik_len);
+                if (rc != TDB_SUCCESS) goto err;
+                rc = tidesdb_txn_put(txn, share->idx_cfs[i], new_ik, new_ik_len, &tdb_empty_val, 1,
+                                     row_ttl);
+                if (rc != TDB_SUCCESS) goto err;
             }
         }
     }
@@ -6143,7 +6373,7 @@ int ha_tidesdb::delete_row(const uchar *buf)
     }
 
     /* We delete data row */
-    uchar dk[MAX_KEY_LENGTH + 2];
+    uchar dk[DATA_KEY_BUF_LEN];
     uint dk_len = build_data_key(current_pk_buf_, current_pk_len_, dk);
     int rc = tidesdb_txn_delete(txn, share->cf, dk, dk_len);
     if (rc != TDB_SUCCESS)
@@ -6152,80 +6382,73 @@ int ha_tidesdb::delete_row(const uchar *buf)
         DBUG_RETURN(tdb_rc_to_ha(rc, "delete_row"));
     }
 
-    /* We delete secondary index entries */
-    if (share->num_secondary_indexes > 0)
-        for (uint i = 0; i < table->s->keys; i++)
-        {
-            if (share->has_user_pk && i == share->pk_index) continue;
-            if (i >= share->idx_cfs.size() || !share->idx_cfs[i]) continue;
-            if (is_fts_index(&table->key_info[i])) continue;
-            if (is_spatial_index(&table->key_info[i])) continue;
-
-            uchar ik[MAX_KEY_LENGTH * 2 + 2];
-            uint ik_len = sec_idx_key(i, buf, ik);
-            rc = tidesdb_txn_delete(txn, share->idx_cfs[i], ik, ik_len);
-            if (rc != TDB_SUCCESS)
-            {
-                tmp_restore_column_map(&table->read_set, old_map);
-                DBUG_RETURN(tdb_rc_to_ha(rc, "delete_row idx"));
-            }
-        }
-
-    /* We delete FULLTEXT index entries */
+    /* We delete secondary index entries in a single consolidated dispatch loop.
+       Regular, FTS, and spatial indexes are handled inline. */
     if (share->num_secondary_indexes > 0)
     {
-        for (uint i = 0; i < table->s->keys; i++)
+        const uint num_keys = table->s->keys;
+        const bool has_user_pk = share->has_user_pk;
+        const uint pk_index = share->pk_index;
+        const size_t idx_cfs_sz = share->idx_cfs.size();
+
+        for (uint i = 0; i < num_keys; i++)
         {
-            if (share->has_user_pk && i == share->pk_index) continue;
-            if (i >= share->idx_cfs.size() || !share->idx_cfs[i]) continue;
-            if (!is_fts_index(&table->key_info[i])) continue;
+            if (has_user_pk && i == pk_index) continue;
+            if (i >= idx_cfs_sz || !share->idx_cfs[i]) continue;
 
-            CHARSET_INFO *fts_cs = table->key_info[i].key_part[0].field->charset();
-            std::vector<fts_token_t> fts_tokens;
-            fts_extract_and_tokenize(table, &table->key_info[i], buf, fts_cs, fts_tokens);
+            KEY *ki = &table->key_info[i];
 
-            std::unordered_map<std::string, uint16> tf_map;
-            for (auto &tok : fts_tokens) tf_map[tok.word]++;
-            uint32 word_count = (uint32)fts_tokens.size();
-
-            for (auto &[term, tf] : tf_map)
+            if (share->idx_is_fts[i])
             {
-                uchar fk[2 + 512 + MAX_KEY_LENGTH];
-                uint fk_len = fts_build_key(term.data(), (uint)term.size(), current_pk_buf_,
-                                            current_pk_len_, fk);
-                tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
+                CHARSET_INFO *fts_cs = ki->key_part[0].field->charset();
+                std::vector<fts_token_t> fts_tokens;
+                fts_extract_and_tokenize(table, ki, buf, fts_cs, fts_tokens);
+
+                std::unordered_map<std::string, uint16> tf_map;
+                for (auto &tok : fts_tokens) tf_map[tok.word]++;
+                uint32 word_count = (uint32)fts_tokens.size();
+
+                for (auto &[term, tf] : tf_map)
+                {
+                    uchar fk[FTS_KEY_BUF_LEN];
+                    uint fk_len = fts_build_key(term.data(), (uint)term.size(), current_pk_buf_,
+                                                current_pk_len_, fk);
+                    tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
+                }
+
+                fts_update_meta(txn, share->cf, i, -1, -(int64_t)word_count);
             }
-
-            fts_update_meta(txn, share->cf, i, -1, -(int64_t)word_count);
-        }
-    }
-
-    /* We delete SPATIAL index entries */
-    if (share->num_secondary_indexes > 0)
-    {
-        for (uint i = 0; i < table->s->keys; i++)
-        {
-            if (share->has_user_pk && i == share->pk_index) continue;
-            if (i >= share->idx_cfs.size() || !share->idx_cfs[i]) continue;
-            if (!is_spatial_index(&table->key_info[i])) continue;
-
-            Field *geom_field = table->key_info[i].key_part[0].field;
-            my_ptrdiff_t ptd = (my_ptrdiff_t)(buf - table->record[0]);
-            geom_field->move_field_offset(ptd);
-            String geom_str;
-            geom_field->val_str(&geom_str, &geom_str);
-            geom_field->move_field_offset(-ptd);
-
-            double xmin, ymin, xmax, ymax;
-            if (geom_str.length() > 0 &&
-                spatial_compute_mbr((const uchar *)geom_str.ptr(), geom_str.length(), &xmin, &ymin,
-                                    &xmax, &ymax))
+            else if (share->idx_is_spatial[i])
             {
-                double cx = (xmin + xmax) / 2.0;
-                double cy = (ymin + ymax) / 2.0;
-                uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
-                uint sk_len = spatial_build_key(cx, cy, current_pk_buf_, current_pk_len_, sk);
-                tidesdb_txn_delete(txn, share->idx_cfs[i], sk, sk_len);
+                Field *geom_field = ki->key_part[0].field;
+                my_ptrdiff_t ptd = (my_ptrdiff_t)(buf - table->record[0]);
+                geom_field->move_field_offset(ptd);
+                String geom_str;
+                geom_field->val_str(&geom_str, &geom_str);
+                geom_field->move_field_offset(-ptd);
+
+                double xmin, ymin, xmax, ymax;
+                if (geom_str.length() > 0 &&
+                    spatial_compute_mbr((const uchar *)geom_str.ptr(), geom_str.length(), &xmin,
+                                        &ymin, &xmax, &ymax))
+                {
+                    double cx = (xmin + xmax) / 2.0;
+                    double cy = (ymin + ymax) / 2.0;
+                    uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
+                    uint sk_len = spatial_build_key(cx, cy, current_pk_buf_, current_pk_len_, sk);
+                    tidesdb_txn_delete(txn, share->idx_cfs[i], sk, sk_len);
+                }
+            }
+            else
+            {
+                uchar ik[SEC_IDX_KEY_BUF_LEN];
+                uint ik_len = sec_idx_key(i, buf, ik);
+                rc = tidesdb_txn_delete(txn, share->idx_cfs[i], ik, ik_len);
+                if (rc != TDB_SUCCESS)
+                {
+                    tmp_restore_column_map(&table->read_set, old_map);
+                    DBUG_RETURN(tdb_rc_to_ha(rc, "delete_row idx"));
+                }
             }
         }
     }
@@ -6276,7 +6499,7 @@ int ha_tidesdb::delete_all_rows(void)
         int rc = tidesdb_drop_column_family(tdb_global, cf_name.c_str());
         if (rc != TDB_SUCCESS && rc != TDB_ERR_NOT_FOUND)
         {
-            sql_print_error("TIDESDB: truncate: failed to drop CF '%s' (err=%d)", cf_name.c_str(),
+            sql_print_error("[TIDESDB] truncate: failed to drop CF '%s' (err=%d)", cf_name.c_str(),
                             rc);
             DBUG_RETURN(tdb_rc_to_ha(rc, "truncate drop_cf"));
         }
@@ -6284,7 +6507,7 @@ int ha_tidesdb::delete_all_rows(void)
         rc = tidesdb_create_column_family(tdb_global, cf_name.c_str(), &cfg);
         if (rc != TDB_SUCCESS)
         {
-            sql_print_error("TIDESDB: truncate: failed to recreate CF '%s' (err=%d)",
+            sql_print_error("[TIDESDB] truncate: failed to recreate CF '%s' (err=%d)",
                             cf_name.c_str(), rc);
             DBUG_RETURN(tdb_rc_to_ha(rc, "truncate create_cf"));
         }
@@ -6292,7 +6515,8 @@ int ha_tidesdb::delete_all_rows(void)
         share->cf = tidesdb_get_column_family(tdb_global, cf_name.c_str());
         if (!share->cf)
         {
-            sql_print_error("TIDESDB: truncate: CF '%s' not found after recreate", cf_name.c_str());
+            sql_print_error("[TIDESDB] truncate: CF '%s' not found after recreate",
+                            cf_name.c_str());
             DBUG_RETURN(HA_ERR_GENERIC);
         }
     }
@@ -6315,7 +6539,7 @@ int ha_tidesdb::delete_all_rows(void)
         int rc = tidesdb_create_column_family(tdb_global, idx_name.c_str(), &idx_cfg);
         if (rc != TDB_SUCCESS)
         {
-            sql_print_warning("TIDESDB: truncate: failed to recreate idx CF '%s' (err=%d)",
+            sql_print_warning("[TIDESDB] truncate: failed to recreate idx CF '%s' (err=%d)",
                               idx_name.c_str(), rc);
             share->idx_cfs[i] = NULL;
             continue;
@@ -6526,13 +6750,13 @@ int ha_tidesdb::analyze(THD *thd, HA_CHECK_OPT *check_opt)
     if (tidesdb_get_stats(share->cf, &st) != TDB_SUCCESS || !st)
     {
         push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_UNKNOWN_ERROR,
-                            "TIDESDB: unable to retrieve column family stats");
+                            "[TIDESDB] unable to retrieve column family stats");
         DBUG_RETURN(HA_ADMIN_OK);
     }
 
     /* Summary line */
     push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_UNKNOWN_ERROR,
-                        "TIDESDB: CF '%s'  total_keys=%llu  data_size=%llu bytes"
+                        "[TIDESDB] CF '%s'  total_keys=%llu  data_size=%llu bytes"
                         "  memtable=%zu bytes  levels=%d  read_amp=%.2f"
                         "  cache_hit=%.1f%%",
                         share->cf_name.c_str(), (unsigned long long)st->total_keys,
@@ -6541,14 +6765,14 @@ int ha_tidesdb::analyze(THD *thd, HA_CHECK_OPT *check_opt)
 
     /* Average sizes */
     push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_UNKNOWN_ERROR,
-                        "TIDESDB: avg_key=%.1f bytes  avg_value=%.1f bytes", st->avg_key_size,
+                        "[TIDESDB] avg_key=%.1f bytes  avg_value=%.1f bytes", st->avg_key_size,
                         st->avg_value_size);
 
     /* Per-level detail */
     for (int i = 0; i < st->num_levels; i++)
     {
         push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_UNKNOWN_ERROR,
-                            "TIDESDB: level %d  sstables=%d  size=%zu bytes"
+                            "[TIDESDB] level %d  sstables=%d  size=%zu bytes"
                             "  keys=%llu",
                             i + 1, st->level_num_sstables[i], st->level_sizes[i],
                             (unsigned long long)st->level_key_counts[i]);
@@ -6558,7 +6782,7 @@ int ha_tidesdb::analyze(THD *thd, HA_CHECK_OPT *check_opt)
     if (st->use_btree)
     {
         push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_UNKNOWN_ERROR,
-                            "TIDESDB: btree  nodes=%llu  max_height=%u"
+                            "[TIDESDB] btree  nodes=%llu  max_height=%u"
                             "  avg_height=%.2f",
                             (unsigned long long)st->btree_total_nodes, st->btree_max_height,
                             st->btree_avg_height);
@@ -6588,7 +6812,7 @@ int ha_tidesdb::analyze(THD *thd, HA_CHECK_OPT *check_opt)
         {
             idx_total_keys = ist->total_keys;
             push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_UNKNOWN_ERROR,
-                                "TIDESDB: idx CF '%s'  keys=%llu  data_size=%llu bytes"
+                                "[TIDESDB] idx CF '%s'  keys=%llu  data_size=%llu bytes"
                                 "  levels=%d",
                                 share->idx_cf_names[i].c_str(), (unsigned long long)ist->total_keys,
                                 (unsigned long long)ist->total_data_size, ist->num_levels);
@@ -6659,7 +6883,7 @@ int ha_tidesdb::analyze(THD *thd, HA_CHECK_OPT *check_opt)
             }
 
             push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE, ER_UNKNOWN_ERROR,
-                                "TIDESDB: idx '%s' sampled=%llu distinct=%llu rec_per_key=%lu",
+                                "[TIDESDB] idx '%s' sampled=%llu distinct=%llu rec_per_key=%lu",
                                 ki->name.str, (unsigned long long)sampled,
                                 (unsigned long long)distinct,
                                 share->cached_rec_per_key[i].load(std::memory_order_relaxed));
@@ -6692,7 +6916,7 @@ int ha_tidesdb::optimize(THD *thd, HA_CHECK_OPT *check_opt)
        table to be fully compacted when the statement returns. */
     int rc = tidesdb_purge_cf(share->cf);
     if (rc != TDB_SUCCESS)
-        sql_print_warning("TIDESDB: optimize: purge data CF '%s' failed (err=%d)",
+        sql_print_warning("[TIDESDB] optimize: purge data CF '%s' failed (err=%d)",
                           share->cf_name.c_str(), rc);
 
     for (uint i = 0; i < share->idx_cfs.size(); i++)
@@ -6700,7 +6924,7 @@ int ha_tidesdb::optimize(THD *thd, HA_CHECK_OPT *check_opt)
         if (!share->idx_cfs[i]) continue;
         rc = tidesdb_purge_cf(share->idx_cfs[i]);
         if (rc != TDB_SUCCESS)
-            sql_print_warning("TIDESDB: optimize: purge idx CF '%s' failed (err=%d)",
+            sql_print_warning("[TIDESDB] optimize: purge idx CF '%s' failed (err=%d)",
                               share->idx_cf_names[i].c_str(), rc);
     }
 
@@ -6725,7 +6949,7 @@ int ha_tidesdb::check(THD *thd, HA_CHECK_OPT *check_opt)
     int rc = tidesdb_get_stats(share->cf, &st);
     if (rc != TDB_SUCCESS)
     {
-        sql_print_error("TIDESDB: CHECK TABLE '%s': data CF check failed (err=%d)",
+        sql_print_error("[TIDESDB] CHECK TABLE '%s': data CF check failed (err=%d)",
                         share->cf_name.c_str(), rc);
         DBUG_RETURN(HA_ADMIN_CORRUPT);
     }
@@ -6738,7 +6962,7 @@ int ha_tidesdb::check(THD *thd, HA_CHECK_OPT *check_opt)
         rc = tidesdb_get_stats(share->idx_cfs[i], &ist);
         if (rc != TDB_SUCCESS)
         {
-            sql_print_error("TIDESDB: CHECK TABLE '%s': index CF '%s' check failed (err=%d)",
+            sql_print_error("[TIDESDB] CHECK TABLE '%s': index CF '%s' check failed (err=%d)",
                             share->cf_name.c_str(), share->idx_cf_names[i].c_str(), rc);
             DBUG_RETURN(HA_ADMIN_CORRUPT);
         }
@@ -6763,7 +6987,7 @@ int ha_tidesdb::repair(THD *thd, HA_CHECK_OPT *check_opt)
     int rc = tidesdb_purge_cf(share->cf);
     if (rc != TDB_SUCCESS)
     {
-        sql_print_error("TIDESDB: REPAIR TABLE '%s': purge data CF failed (err=%d)",
+        sql_print_error("[TIDESDB] REPAIR TABLE '%s': purge data CF failed (err=%d)",
                         share->cf_name.c_str(), rc);
         DBUG_RETURN(HA_ADMIN_FAILED);
     }
@@ -6773,7 +6997,7 @@ int ha_tidesdb::repair(THD *thd, HA_CHECK_OPT *check_opt)
         if (!share->idx_cfs[i]) continue;
         rc = tidesdb_purge_cf(share->idx_cfs[i]);
         if (rc != TDB_SUCCESS)
-            sql_print_warning("TIDESDB: REPAIR TABLE '%s': purge idx CF '%s' failed (err=%d)",
+            sql_print_warning("[TIDESDB] REPAIR TABLE '%s': purge idx CF '%s' failed (err=%d)",
                               share->cf_name.c_str(), share->idx_cf_names[i].c_str(), rc);
     }
 
@@ -6821,7 +7045,7 @@ IO_AND_CPU_COST ha_tidesdb::scan_time()
     if (stale)
     {
         uchar lo[2] = {KEY_NS_DATA};
-        uchar hi[MAX_KEY_LENGTH + 2];
+        uchar hi[DATA_KEY_BUF_LEN];
         memset(hi, 0xFF, sizeof(hi));
         uint hi_len = 1 + share->pk_key_len;
         if (hi_len > sizeof(hi)) hi_len = sizeof(hi);
@@ -6841,8 +7065,8 @@ IO_AND_CPU_COST ha_tidesdb::scan_time()
 
     if (cached_cost > 0.0)
     {
-        cost.io = cached_cost * 0.9;
-        cost.cpu = cached_cost * 0.1;
+        cost.io = cached_cost * TIDESDB_SCAN_IO_WEIGHT;
+        cost.cpu = cached_cost * TIDESDB_SCAN_CPU_WEIGHT;
     }
     else
     {
@@ -6855,7 +7079,7 @@ IO_AND_CPU_COST ha_tidesdb::scan_time()
 ha_rows ha_tidesdb::records_in_range(uint inx, const key_range *min_key, const key_range *max_key,
                                      page_range *pages)
 {
-    if (!share) return 10;
+    if (!share) return TIDESDB_RIR_DEFAULT_EST;
 
     ha_rows total = share->cached_records.load(std::memory_order_relaxed);
     if (total == 0) total = TIDESDB_MIN_STATS_RECORDS;
@@ -6868,12 +7092,12 @@ ha_rows ha_tidesdb::records_in_range(uint inx, const key_range *min_key, const k
     else if (inx < share->idx_cfs.size() && share->idx_cfs[inx])
         cf = share->idx_cfs[inx];
     else
-        return (total / 4) + 1; /* fallback -- no CF for this index */
+        return (total / TIDESDB_RIR_UNKNOWN_DENOM) + 1; /* no CF for this index */
 
     /* We convert min_key / max_key to our comparable format.
        If a bound is missing we use the natural boundary of the key space. */
-    uchar lo_buf[MAX_KEY_LENGTH + 2];
-    uchar hi_buf[MAX_KEY_LENGTH + 2];
+    uchar lo_buf[DATA_KEY_BUF_LEN];
+    uchar hi_buf[DATA_KEY_BUF_LEN];
     uint lo_len = 0, hi_len = 0;
 
     MY_BITMAP *old_map = tmp_use_all_columns(table, &table->read_set);
@@ -6956,20 +7180,21 @@ ha_rows ha_tidesdb::records_in_range(uint inx, const key_range *min_key, const k
        block indexes, SSTable min/max keys, and entry counts). */
     double range_cost = 0.0;
     int rc = tidesdb_range_cost(cf, lo_buf, lo_len, hi_buf, hi_len, &range_cost);
-    if (rc != TDB_SUCCESS || range_cost <= 0.0) return (total / 4) + 1; /* fallback */
+    if (rc != TDB_SUCCESS || range_cost <= 0.0)
+        return (total / TIDESDB_RIR_UNKNOWN_DENOM) + 1; /* fallback */
 
     /* We get full-range cost for normalization.  We use the natural boundaries
        of the key space so that range_cost / full_cost ≈ fraction of data. */
     double full_cost = 0.0;
     {
         uchar full_lo[2] = {(uchar)(is_pk ? KEY_NS_DATA : 0x00)};
-        uchar full_hi[MAX_KEY_LENGTH + 2];
+        uchar full_hi[DATA_KEY_BUF_LEN];
         memset(full_hi, 0xFF, sizeof(full_hi));
         uint full_hi_len = hi_len; /* same width as hi_buf */
         tidesdb_range_cost(cf, full_lo, 1, full_hi, full_hi_len, &full_cost);
     }
 
-    if (full_cost <= 0.0) return (total / 4) + 1; /* fallback */
+    if (full_cost <= 0.0) return (total / TIDESDB_RIR_UNKNOWN_DENOM) + 1; /* fallback */
 
     /* We estimate records proportionally -- narrower range -> fewer records */
     double fraction = range_cost / full_cost;
@@ -6979,13 +7204,12 @@ ha_rows ha_tidesdb::records_in_range(uint inx, const key_range *min_key, const k
     ha_rows est = (ha_rows)(total * fraction);
     if (est == 0) est = 1; /* never return 0 -- optimizer treats it as "empty" */
 
-    /* When both bounds are provided but the estimated fraction
-       is very high (>0.8), tidesdb_range_cost is likely unreliable - this
-       happens with memtable-only data where the cost function cannot
-       distinguish a narrow range from a full scan.
-
-       Fall back to a rec_per_key-based estimate for the key prefix. */
-    if (min_key && max_key && fraction > 0.8)
+    /* When both bounds are provided but the estimated fraction is very
+       high (>TIDESDB_RIR_FRACTION_UNRELIABLE), tidesdb_range_cost is
+       likely unreliable -- this happens with memtable-only data where
+       the cost function cannot distinguish a narrow range from a full
+       scan.  Fall back to a rec_per_key-based estimate for the prefix. */
+    if (min_key && max_key && fraction > TIDESDB_RIR_FRACTION_UNRELIABLE)
     {
         KEY *ki = &table->key_info[inx];
         uint parts = my_count_bits(min_key->keypart_map);
@@ -7092,11 +7316,15 @@ int ha_tidesdb::spatial_scan_next(uchar *buf)
                 continue;
             }
 
+            /* The on-disk spatial value is exactly SPATIAL_MBR_VALUE_LEN bytes
+               laid out as [xmin,ymin,xmax,ymax] (4 doubles in native order),
+               matching tdb_mbr_t's field order.  We assert the struct size
+               against the wire size so adding a field to tdb_mbr_t will
+               fire the static_assert rather than silently corrupt reads. */
+            static_assert(sizeof(tdb_mbr_t) == SPATIAL_MBR_VALUE_LEN,
+                          "tdb_mbr_t must match on-disk spatial value layout");
             tdb_mbr_t entry_mbr;
-            memcpy(&entry_mbr.xmin, val, 8);
-            memcpy(&entry_mbr.ymin, val + 8, 8);
-            memcpy(&entry_mbr.xmax, val + 16, 8);
-            memcpy(&entry_mbr.ymax, val + 24, 8);
+            memcpy(&entry_mbr, val, SPATIAL_MBR_VALUE_LEN);
 
             /* We apply MBR predicate */
             if (!spatial_mbr_predicate(spatial_mode_, &query_mbr, &entry_mbr))
@@ -7203,6 +7431,10 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
     fts_load_meta(stmt_txn, share->cf, inx, &total_docs, &total_words);
     double avgdl = total_docs > 0 ? (double)total_words / (double)total_docs : 1.0;
     if (total_docs == 0) total_docs = 1; /* avoid division by zero */
+    /* Precompute 1/avgdl so the per-posting BM25 loop multiplies instead of
+       dividing.  Divisions are expensive on modern CPUs (~20 cycles vs ~5
+       for a multiply) and this runs per term per matched document. */
+    const double inv_avgdl = 1.0 / avgdl;
 
     /* For each query term, prefix-scan the FTS CF to gather postings and score */
     std::unordered_map<std::string, double> doc_scores;
@@ -7215,10 +7447,10 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
         if (qt.yesno > 0) num_required++;
 
         /* We build prefix key-- [2-byte term_len][term bytes] */
-        uchar prefix[2 + FTS_MAX_TERM_BYTES];
+        uchar prefix[FTS_TERM_LEN_PREFIX + FTS_MAX_TERM_BYTES];
         uint prefix_len = 0;
         int2store(prefix, (uint16)qt.term.size());
-        prefix_len += 2;
+        prefix_len += FTS_TERM_LEN_PREFIX;
         memcpy(prefix + prefix_len, qt.term.data(), qt.term.size());
         prefix_len += (uint)qt.term.size();
 
@@ -7249,10 +7481,10 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
             for (uint tlen = min_len; tlen <= max_len; tlen++)
             {
                 /* We build seek key--[2B tlen][prefix bytes] */
-                uchar seek[2 + FTS_MAX_TERM_BYTES];
+                uchar seek[FTS_TERM_LEN_PREFIX + FTS_MAX_TERM_BYTES];
                 int2store(seek, (uint16)tlen);
-                memcpy(seek + 2, qt.term.data(), qt.term.size());
-                uint seek_len = 2 + (uint)qt.term.size();
+                memcpy(seek + FTS_TERM_LEN_PREFIX, qt.term.data(), qt.term.size());
+                uint seek_len = FTS_TERM_LEN_PREFIX + (uint)qt.term.size();
 
                 tidesdb_iter_seek(it, seek, seek_len);
                 while (tidesdb_iter_valid(it))
@@ -7262,16 +7494,17 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
                     if (tidesdb_iter_key(it, &ik, &iks) != TDB_SUCCESS) break;
 
                     /* We verify we're still in the same length bucket */
-                    if (iks < 2) break;
+                    if (iks < FTS_TERM_LEN_PREFIX) break;
                     uint16 stored_len = uint2korr(ik);
                     if (stored_len != tlen) break;
 
                     /* We verify prefix match */
-                    if (iks < (size_t)(2 + stored_len)) break;
-                    if (memcmp(ik + 2, qt.term.data(), qt.term.size()) != 0) break;
+                    if (iks < (size_t)(FTS_TERM_LEN_PREFIX + stored_len)) break;
+                    if (memcmp(ik + FTS_TERM_LEN_PREFIX, qt.term.data(), qt.term.size()) != 0)
+                        break;
 
                     /* We extract PK and value */
-                    uint pk_off = 2 + stored_len;
+                    uint pk_off = FTS_TERM_LEN_PREFIX + stored_len;
                     if (iks <= pk_off)
                     {
                         tidesdb_iter_next(it);
@@ -7281,8 +7514,9 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
 
                     uint8_t *iv = NULL;
                     size_t ivs = 0;
-                    if (tidesdb_iter_value(it, &iv, &ivs) == TDB_SUCCESS && ivs >= 6)
-                        postings.push_back({pk, (uint16)uint2korr(iv), (uint32)uint4korr(iv + 2)});
+                    if (tidesdb_iter_value(it, &iv, &ivs) == TDB_SUCCESS && ivs >= FTS_VALUE_LEN)
+                        postings.push_back({pk, (uint16)uint2korr(iv),
+                                            (uint32)uint4korr(iv + FTS_VALUE_DOC_LEN_OFFSET)});
 
                     tidesdb_iter_next(it);
                 }
@@ -7309,8 +7543,9 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
 
                     uint8_t *iv = NULL;
                     size_t ivs = 0;
-                    if (tidesdb_iter_value(it, &iv, &ivs) == TDB_SUCCESS && ivs >= 6)
-                        postings.push_back({pk, (uint16)uint2korr(iv), (uint32)uint4korr(iv + 2)});
+                    if (tidesdb_iter_value(it, &iv, &ivs) == TDB_SUCCESS && ivs >= FTS_VALUE_LEN)
+                        postings.push_back({pk, (uint16)uint2korr(iv),
+                                            (uint32)uint4korr(iv + FTS_VALUE_DOC_LEN_OFFSET)});
                 }
                 tidesdb_iter_next(it);
             }
@@ -7324,7 +7559,7 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
         for (auto &p : postings)
         {
             double tf_norm = ((double)p.tf * (k1 + 1.0)) /
-                             ((double)p.tf + k1 * (1.0 - b + b * (double)p.doc_len / avgdl));
+                             ((double)p.tf + k1 * (1.0 - b + b * (double)p.doc_len * inv_avgdl));
             double score = idf * tf_norm;
 
             if (qt.yesno < 0)
@@ -7392,17 +7627,23 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
     {
         CHARSET_INFO *vcs = table->key_info[inx].key_part[0].field->charset();
         std::vector<tdb_fts_result_t> verified;
+        /* Tokenize each candidate once and check all phrases against the
+           single token vector.  The old code tokenized the same doc M times
+           when M phrases were pending. */
+        std::vector<fts_token_t> doc_tokens;
         for (auto &r : info->results)
         {
-            /* We fetch the row to verify the phrase */
             int err = fetch_row_by_pk(stmt_txn, r.pk, r.pk_len, table->record[0]);
             if (err) continue;
+
+            doc_tokens.clear();
+            fts_extract_and_tokenize(table, &table->key_info[inx], table->record[0], vcs,
+                                     doc_tokens);
 
             bool all_phrases_match = true;
             for (auto *ph : phrases)
             {
-                if (!fts_verify_phrase(table, &table->key_info[inx], table->record[0], vcs,
-                                       ph->phrase_words))
+                if (!fts_phrase_in_tokens(doc_tokens, ph->phrase_words))
                 {
                     all_phrases_match = false;
                     break;
@@ -7517,13 +7758,27 @@ int ha_tidesdb::ensure_stmt_txn()
        Autocommit single-statement DML uses READ_COMMITTED (no
        concurrent modification within a single-stmt txn to conflict with).
        Multi-statement transactions (BEGIN...COMMIT) use the session's
-       isolation level so that write-write conflict detection is active. */
-    int sql_cmd = thd_sql_command(thd);
+       isolation level so that write-write conflict detection is active.
+
+       Prefer the per-statement cache populated by external_lock; fall
+       through to the live THD call only on paths where external_lock
+       hasn't run yet (e.g. some DDL callbacks). */
+    int sql_cmd;
+    bool is_autocommit;
+    if (cached_stmt_shape_valid_)
+    {
+        sql_cmd = cached_sql_cmd_;
+        is_autocommit = cached_is_autocommit_;
+    }
+    else
+    {
+        sql_cmd = thd_sql_command(thd);
+        is_autocommit = !thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
+    }
     bool is_ddl =
         (sql_cmd == SQLCOM_ALTER_TABLE || sql_cmd == SQLCOM_CREATE_INDEX ||
          sql_cmd == SQLCOM_DROP_INDEX || sql_cmd == SQLCOM_TRUNCATE || sql_cmd == SQLCOM_OPTIMIZE ||
          sql_cmd == SQLCOM_CREATE_TABLE || sql_cmd == SQLCOM_DROP_TABLE);
-    bool is_autocommit = !thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
     tidesdb_isolation_level_t effective_iso;
     if (is_ddl || is_autocommit)
         effective_iso = TDB_ISOLATION_READ_COMMITTED;
@@ -7549,12 +7804,20 @@ int ha_tidesdb::external_lock(THD *thd, int lock_type)
 
     if (lock_type != F_UNLCK)
     {
+        /* Resolve per-statement THD shape once and cache -- ensure_stmt_txn
+           reads the cache instead of re-calling thd_sql_command() and
+           thd_test_options(). */
         int sql_cmd = thd_sql_command(thd);
         bool is_ddl = (sql_cmd == SQLCOM_ALTER_TABLE || sql_cmd == SQLCOM_CREATE_INDEX ||
                        sql_cmd == SQLCOM_DROP_INDEX || sql_cmd == SQLCOM_TRUNCATE ||
                        sql_cmd == SQLCOM_OPTIMIZE || sql_cmd == SQLCOM_CREATE_TABLE ||
                        sql_cmd == SQLCOM_DROP_TABLE);
         bool is_autocommit = !thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
+
+        cached_sql_cmd_ = sql_cmd;
+        cached_is_autocommit_ = is_autocommit;
+        cached_stmt_shape_valid_ = true;
+
         tidesdb_isolation_level_t effective_iso;
         if (is_ddl || is_autocommit)
             effective_iso = TDB_ISOLATION_READ_COMMITTED;
@@ -7579,8 +7842,7 @@ int ha_tidesdb::external_lock(THD *thd, int lock_type)
         trans_register_ha(thd, false, ht, 0);
 
         /* We register at transaction level if inside BEGIN block */
-        if (thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN))
-            trans_register_ha(thd, true, ht, 0);
+        if (!is_autocommit) trans_register_ha(thd, true, ht, 0);
     }
     else
     {
@@ -7591,7 +7853,10 @@ int ha_tidesdb::external_lock(THD *thd, int lock_type)
            After WRITE statements, iterators must be invalidated because
            new txn ops (puts/deletes) are not visible to iterators created
            before those ops were added.  For autocommit, always free. */
-        bool in_multi_stmt = thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
+        bool in_multi_stmt =
+            cached_stmt_shape_valid_
+                ? !cached_is_autocommit_
+                : (bool)thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
         if (!in_multi_stmt || stmt_txn_dirty)
         {
             if (scan_iter)
@@ -7625,7 +7890,14 @@ int ha_tidesdb::external_lock(THD *thd, int lock_type)
         /* We reset trx_registered_ for autocommit, the txn will be freed
            in tidesdb_commit and a new one created next time.
            For multi-stmt (BEGIN...COMMIT), keep it true since the txn persists. */
-        if (!thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN)) trx_registered_ = false;
+        bool was_autocommit = cached_stmt_shape_valid_
+                                  ? cached_is_autocommit_
+                                  : !thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN);
+        if (was_autocommit) trx_registered_ = false;
+
+        /* Invalidate statement shape cache last so the above checks still
+           see it. */
+        cached_stmt_shape_valid_ = false;
     }
 
     DBUG_RETURN(0);
@@ -7776,18 +8048,18 @@ bool ha_tidesdb::prepare_inplace_alter_table(TABLE *altered_table,
             int rc = tidesdb_create_column_family(tdb_global, idx_cf.c_str(), &idx_cfg);
             if (rc != TDB_SUCCESS)
             {
-                sql_print_error("TIDESDB: inplace ADD INDEX: failed to create CF '%s' (err=%d)",
+                sql_print_error("[TIDESDB] inplace ADD INDEX: failed to create CF '%s' (err=%d)",
                                 idx_cf.c_str(), rc);
-                my_error(ER_INTERNAL_ERROR, MYF(0), "TidesDB: failed to create index CF");
+                my_error(ER_INTERNAL_ERROR, MYF(0), "[TIDESDB] failed to create index CF");
                 DBUG_RETURN(true);
             }
 
             tidesdb_column_family_t *icf = tidesdb_get_column_family(tdb_global, idx_cf.c_str());
             if (!icf)
             {
-                sql_print_error("TIDESDB: inplace ADD INDEX: CF '%s' not found after create",
+                sql_print_error("[TIDESDB] inplace ADD INDEX: CF '%s' not found after create",
                                 idx_cf.c_str());
-                my_error(ER_INTERNAL_ERROR, MYF(0), "TidesDB: index CF not found after create");
+                my_error(ER_INTERNAL_ERROR, MYF(0), "[TIDESDB] index CF not found after create");
                 DBUG_RETURN(true);
             }
 
@@ -7845,8 +8117,8 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
     int rc = tidesdb_txn_begin_with_isolation(tdb_global, TDB_ISOLATION_READ_COMMITTED, &txn);
     if (rc != TDB_SUCCESS || !txn)
     {
-        sql_print_error("TIDESDB: inplace ADD INDEX: txn_begin failed (err=%d)", rc);
-        my_error(ER_INTERNAL_ERROR, MYF(0), "TidesDB: failed to begin txn for index build");
+        sql_print_error("[TIDESDB] inplace ADD INDEX: txn_begin failed (err=%d)", rc);
+        my_error(ER_INTERNAL_ERROR, MYF(0), "[TIDESDB] failed to begin txn for index build");
         tmp_restore_column_map(&altered_table->read_set, old_map);
         DBUG_RETURN(true);
     }
@@ -7856,8 +8128,8 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
     if (rc != TDB_SUCCESS || !iter)
     {
         tidesdb_txn_free(txn);
-        sql_print_error("TIDESDB: inplace ADD INDEX: iter_new failed (err=%d)", rc);
-        my_error(ER_INTERNAL_ERROR, MYF(0), "TidesDB: failed to create iterator for index build");
+        sql_print_error("[TIDESDB] inplace ADD INDEX: iter_new failed (err=%d)", rc);
+        my_error(ER_INTERNAL_ERROR, MYF(0), "[TIDESDB] failed to create iterator for index build");
         tmp_restore_column_map(&altered_table->read_set, old_map);
         DBUG_RETURN(true);
     }
@@ -7880,7 +8152,7 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
 
     /* We remember the last data key so we can seek directly to it after
        a batch commit (O(n²)). */
-    uchar last_data_key[MAX_KEY_LENGTH + 2];
+    uchar last_data_key[DATA_KEY_BUF_LEN];
     size_t last_data_key_len = 0;
 
     while (tidesdb_iter_valid(iter))
@@ -7944,7 +8216,7 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
             if (is_fts_index(ki)) continue;
             if (is_spatial_index(ki)) continue;
 
-            uchar ik[MAX_KEY_LENGTH * 2 + 2];
+            uchar ik[SEC_IDX_KEY_BUF_LEN];
             uint pos = 0;
             for (uint p = 0; p < ki->user_defined_key_parts; p++)
             {
@@ -7993,7 +8265,7 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
                 tidesdb_txn_put(txn, ctx->add_cfs[a], ik, pos, &tdb_empty_val, 1, TIDESDB_TTL_NONE);
             if (rc != TDB_SUCCESS)
             {
-                sql_print_error("TIDESDB: inplace ADD INDEX: put failed for key %u (err=%d)",
+                sql_print_error("[TIDESDB] inplace ADD INDEX: put failed for key %u (err=%d)",
                                 key_num, rc);
                 /* Continue, best effort from here! */
             }
@@ -8019,7 +8291,8 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
                 int crc = tidesdb_txn_commit(txn);
                 if (crc != TDB_SUCCESS)
                 {
-                    sql_print_warning("TIDESDB: inplace ADD INDEX: batch commit failed rc=%d", crc);
+                    sql_print_warning("[TIDESDB] inplace ADD INDEX: batch commit failed rc=%d",
+                                      crc);
                     tidesdb_txn_rollback(txn);
                 }
             }
@@ -8031,15 +8304,19 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
             if (rrc != TDB_SUCCESS)
             {
                 /* We reset failed -- fall back to free+begin */
+                sql_print_warning(
+                    "[TIDESDB] inplace ADD INDEX: tidesdb_txn_reset failed (rc=%d), "
+                    "falling back to free+begin",
+                    rrc);
                 tidesdb_txn_free(txn);
                 txn = NULL;
                 rc = tidesdb_txn_begin_with_isolation(tdb_global, TDB_ISOLATION_READ_COMMITTED,
                                                       &txn);
                 if (rc != TDB_SUCCESS || !txn)
                 {
-                    sql_print_error("TIDESDB: inplace ADD INDEX: batch txn_begin failed");
+                    sql_print_error("[TIDESDB] inplace ADD INDEX: batch txn_begin failed");
                     my_error(ER_INTERNAL_ERROR, MYF(0),
-                             "TidesDB: batch txn failed during index build");
+                             "[TIDESDB] batch txn failed during index build");
                     tmp_restore_column_map(&altered_table->read_set, old_map);
                     DBUG_RETURN(true);
                 }
@@ -8050,7 +8327,7 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
             {
                 tidesdb_txn_free(txn);
                 my_error(ER_INTERNAL_ERROR, MYF(0),
-                         "TidesDB: batch iter failed during index build");
+                         "[TIDESDB] batch iter failed during index build");
                 tmp_restore_column_map(&altered_table->read_set, old_map);
                 DBUG_RETURN(true);
             }
@@ -8058,7 +8335,7 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
             int src = tidesdb_iter_seek(iter, last_data_key, last_data_key_len);
             if (src != TDB_SUCCESS)
             {
-                sql_print_warning("TIDESDB: inplace ADD INDEX: iter_seek failed rc=%d", src);
+                sql_print_warning("[TIDESDB] inplace ADD INDEX: iter_seek failed rc=%d", src);
                 break; /* end scan gracefully */
             }
             if (tidesdb_iter_valid(iter)) tidesdb_iter_next(iter);
@@ -8077,8 +8354,8 @@ bool ha_tidesdb::inplace_alter_table(TABLE *altered_table, Alter_inplace_info *h
 
     if (rc != TDB_SUCCESS)
     {
-        sql_print_error("TIDESDB: inplace ADD INDEX: final commit failed (err=%d)", rc);
-        my_error(ER_INTERNAL_ERROR, MYF(0), "TidesDB: final commit failed during index build");
+        sql_print_error("[TIDESDB] inplace ADD INDEX: final commit failed (err=%d)", rc);
+        my_error(ER_INTERNAL_ERROR, MYF(0), "[TIDESDB] final commit failed during index build");
         tmp_restore_column_map(&altered_table->read_set, old_map);
         DBUG_RETURN(true);
     }
@@ -8127,7 +8404,7 @@ bool ha_tidesdb::commit_inplace_alter_table(TABLE *altered_table, Alter_inplace_
     {
         int rc = tidesdb_drop_column_family(tdb_global, cf_name.c_str());
         if (rc != TDB_SUCCESS && rc != TDB_ERR_NOT_FOUND)
-            sql_print_warning("TIDESDB: commit ALTER: failed to drop CF '%s' (err=%d)",
+            sql_print_warning("[TIDESDB] commit ALTER: failed to drop CF '%s' (err=%d)",
                               cf_name.c_str(), rc);
     }
 
@@ -8155,7 +8432,34 @@ bool ha_tidesdb::commit_inplace_alter_table(TABLE *altered_table, Alter_inplace_
 
     /* We recompute cached index metadata for the new table shape */
     for (uint i = 0; i < altered_table->s->keys; i++)
+    {
         share->idx_comp_key_len[i] = comparable_key_length(&altered_table->key_info[i]);
+        share->idx_is_fts[i] = is_fts_index(&altered_table->key_info[i]);
+        share->idx_is_spatial[i] = is_spatial_index(&altered_table->key_info[i]);
+    }
+
+    /* Repopulate coverage bitmaps for the new table shape. */
+    share->idx_cover.assign(altered_table->s->keys,
+                            std::vector<bool>(altered_table->s->fields, false));
+    for (uint i = 0; i < altered_table->s->keys; i++)
+    {
+        const KEY *ki = &altered_table->key_info[i];
+        for (uint p = 0; p < ki->user_defined_key_parts; p++)
+        {
+            uint fnr = ki->key_part[p].fieldnr;
+            if (fnr > 0 && fnr - 1 < altered_table->s->fields) share->idx_cover[i][fnr - 1] = true;
+        }
+        if (altered_table->s->primary_key != MAX_KEY && i != altered_table->s->primary_key)
+        {
+            const KEY *pk_key = &altered_table->key_info[altered_table->s->primary_key];
+            for (uint p = 0; p < pk_key->user_defined_key_parts; p++)
+            {
+                uint fnr = pk_key->key_part[p].fieldnr;
+                if (fnr > 0 && fnr - 1 < altered_table->s->fields)
+                    share->idx_cover[i][fnr - 1] = true;
+            }
+        }
+    }
     share->num_secondary_indexes = 0;
     for (uint i = 0; i < share->idx_cfs.size(); i++)
         if (share->idx_cfs[i]) share->num_secondary_indexes++;
@@ -8173,7 +8477,7 @@ bool ha_tidesdb::commit_inplace_alter_table(TABLE *altered_table, Alter_inplace_
             int rc = tidesdb_cf_update_runtime_config(share->cf, &cfg, 1);
             if (rc != TDB_SUCCESS)
                 sql_print_information(
-                    "TIDESDB: ALTER: failed to update runtime config for "
+                    "[TIDESDB] ALTER: failed to update runtime config for "
                     "data CF '%s' (err=%d)",
                     share->cf_name.c_str(), rc);
         }
@@ -8193,7 +8497,7 @@ bool ha_tidesdb::commit_inplace_alter_table(TABLE *altered_table, Alter_inplace_
                 int rc = tidesdb_cf_update_runtime_config(share->idx_cfs[i], &idx_cfg, 1);
                 if (rc != TDB_SUCCESS)
                     sql_print_information(
-                        "TIDESDB: ALTER: failed to update runtime config for "
+                        "[TIDESDB] ALTER: failed to update runtime config for "
                         "index CF '%s' (err=%d)",
                         share->idx_cf_names[i].c_str(), rc);
             }
@@ -8258,7 +8562,7 @@ int ha_tidesdb::rename_table(const char *from, const char *to)
     int rc = tidesdb_rename_column_family(tdb_global, old_cf.c_str(), new_cf.c_str());
     if (rc != TDB_SUCCESS && rc != TDB_ERR_NOT_FOUND)
     {
-        sql_print_error("TIDESDB: Failed to rename CF '%s' -> '%s' (err=%d)", old_cf.c_str(),
+        sql_print_error("[TIDESDB] Failed to rename CF '%s' -> '%s' (err=%d)", old_cf.c_str(),
                         new_cf.c_str(), rc);
         DBUG_RETURN(tdb_rc_to_ha(rc, "rename_table"));
     }
@@ -8283,7 +8587,7 @@ int ha_tidesdb::rename_table(const char *from, const char *to)
                     tidesdb_drop_column_family(tdb_global, new_idx.c_str());
                     rc = tidesdb_rename_column_family(tdb_global, cf_str.c_str(), new_idx.c_str());
                     if (rc != TDB_SUCCESS && rc != TDB_ERR_NOT_FOUND)
-                        sql_print_error("TIDESDB: Failed to rename idx CF '%s' -> '%s' (err=%d)",
+                        sql_print_error("[TIDESDB] Failed to rename idx CF '%s' -> '%s' (err=%d)",
                                         cf_str.c_str(), new_idx.c_str(), rc);
                 }
                 free(names[i]);
@@ -8320,7 +8624,7 @@ static void force_remove_cf_dir(const std::string &cf_name)
     /* my_rmtree() is MariaDB's portable recursive directory removal
        (handles Windows, symlinks, read-only attrs, etc.). */
     if (my_rmtree(dir, MYF(0)) != 0)
-        sql_print_warning("TIDESDB: force_remove_cf_dir failed for %s", dir);
+        sql_print_warning("[TIDESDB] force_remove_cf_dir failed for %s", dir);
 }
 
 /*
@@ -8358,7 +8662,7 @@ static int tidesdb_drop_table_impl(const char *path)
     int rc = tidesdb_drop_column_family(tdb_global, cf_name.c_str());
     if (rc != TDB_SUCCESS && rc != TDB_ERR_NOT_FOUND)
     {
-        sql_print_error("TIDESDB: Failed to drop CF '%s' (err=%d)", cf_name.c_str(), rc);
+        sql_print_error("[TIDESDB] Failed to drop CF '%s' (err=%d)", cf_name.c_str(), rc);
         return rc;
     }
 
@@ -8420,8 +8724,8 @@ static long long srv_stat_cache_misses;
 static double srv_stat_cache_hit_rate;
 static long long srv_stat_cache_partitions;
 
-#define TIDESQL_VERSION_STR "4.2.4"
-#define TIDESQL_VERSION_HEX 0x40204
+#define TIDESQL_VERSION_STR "4.2.5"
+#define TIDESQL_VERSION_HEX 0x40205
 
 static const char *srv_stat_version = TIDESQL_VERSION_STR;
 static long long srv_stat_version_hex = TIDESQL_VERSION_HEX;

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -157,12 +157,12 @@ static handlerton *tidesdb_hton;
   Hash-table-based row-level lock manager with deadlock detection.
 
   Design:
-  - Partitioned hash table      -- hash(pk_bytes) % NUM_PARTITIONS -> partition
-  - Each partition has its own mutex protecting a linked-list hash chain
-  - Lock entries track          -- owner txn, PK bytes, condition variable for waiters
-  - Deadlock detection          -- on wait, walk the wait-for graph (waiter->holder->waiter)
-    If a cycle is found, return HA_ERR_LOCK_DEADLOCK immediately
-  - Per-txn held_locks list for bulk release at COMMIT/ROLLBACK
+  -- Partitioned hash table       hash(pk_bytes) % NUM_PARTITIONS -> partition
+  -- Each partition has its own mutex protecting a linked-list hash chain
+  -- Lock entries track           owner txn, PK bytes, condition variable for waiters
+  -- Deadlock detection           on wait, walk the wait-for graph (waiter->holder->waiter)
+     If a cycle is found, return HA_ERR_LOCK_DEADLOCK immediately
+  -- Per-txn held_locks list for bulk release at COMMIT/ROLLBACK
 
   This gives per-row granularity without false sharing, proper blocking
   semantics for SELECT ... FOR UPDATE, and deadlock resolution for
@@ -642,9 +642,9 @@ static ulong srv_fts_max_word_len = 84;
    word characters.  When a blend char appears inside a token, the tokenizer
    emits three tokens -- the full blended form, and the two parts on each side.
    For example, with blend_chars="'" and input "l'aria":
-     - "l'aria" (full blended token)
-     - "l"      (left part, may be filtered by min_word_len)
-     - "aria"   (right part)
+     -- "l'aria" (full blended token)
+     -- "l"      (left part, may be filtered by min_word_len)
+     -- "aria"   (right part)
    This allows Italian/French elision (dell'aria, l'homme) and Irish/Scottish
    names (O'Malley) to be searchable by any component or the full form.
    Default is empty (no blend characters). Set to "'" for Romance languages. */
@@ -3718,6 +3718,10 @@ ha_tidesdb::ha_tidesdb(handlerton *hton, TABLE_SHARE *table_arg)
       in_bulk_update_(false),
       in_bulk_delete_(false),
       bulk_insert_ops_(0),
+      mrr_custom_active_(false),
+      mrr_no_assoc_(false),
+      mrr_keyno_(MAX_KEY),
+      mrr_next_idx_(0),
       keyread_only_(false),
       write_can_replace_(false)
 {
@@ -4262,7 +4266,7 @@ check_result_t ha_tidesdb::icp_check_secondary(const uint8_t *ik, size_t iks, ui
            like DECIMAL, VARCHAR, multi-byte CHAR).  Fall back to a full PK
            row fetch so ALL columns are available for condition evaluation.
            This is more expensive than pure ICP (still does the PK lookup)
-           but is correct - the server won't re-evaluate pushed conditions. */
+           but is correct, the server won't re-evaluate pushed conditions. */
         if (iks > idx_col_len)
         {
             const uchar *pk = ik + idx_col_len;
@@ -6883,6 +6887,187 @@ Item *ha_tidesdb::idx_cond_push(uint keyno, Item *idx_cond)
 
     /* We ret NULL to indicate we accepted the entire condition */
     DBUG_RETURN(NULL);
+}
+
+/* ******************** Multi-Range Read (MRR) ******************** */
+
+/*
+  Decide whether to accept a custom MRR strategy.  We only handle the case
+  where every range the optimizer hands us is a full-key point lookup
+  (UNIQUE_RANGE|EQ_RANGE) -- typically `WHERE col IN (v1, v2, ...)` on a
+  PK or full-key unique index.  For mixed or true-range sequences we leave
+  HA_MRR_USE_DEFAULT_IMPL set so the handler::multi_range_read_* default
+  path runs unchanged.
+
+  Iterating the sequence here consumes it; MariaDB re-initialises it before
+  calling multi_range_read_init, so probing is safe.
+*/
+ha_rows ha_tidesdb::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq, void *seq_init_param,
+                                                uint n_ranges_arg, uint *bufsz, uint *mrr_mode,
+                                                ha_rows limit, Cost_estimate *cost)
+{
+    /* Compute the default cost + flags first so non-accepted sequences fall
+       through to the server's MRR->read_range_first path with correct costing. */
+    ha_rows rows = handler::multi_range_read_info_const(keyno, seq, seq_init_param, n_ranges_arg,
+                                                        bufsz, mrr_mode, limit, cost);
+    if (rows == HA_POS_ERROR) return rows;
+
+    /* Partitioned tables are served by ha_partition, which dispatches
+       multi_range_read_* across child handlers using its own DS-MRR-backed
+       logic.  If we clear HA_MRR_USE_DEFAULT_IMPL here, ha_partition's
+       ordered-index-scan path ends up invoking our custom _next without
+       the state its own ordering logic expects and crashes.  Refuse to
+       accept MRR for partitioned tables -- the default path runs correctly. */
+    if (table && table->part_info) return rows;
+
+    /* Probe the sequence, we accept only if every range is a full single-point
+       equality.  A single non-point range forces us back to the default path. */
+    KEY_MULTI_RANGE range;
+    range_seq_t it = seq->init(seq_init_param, n_ranges_arg, *mrr_mode);
+    bool all_point = true;
+    uint count = 0;
+    while (!seq->next(it, &range))
+    {
+        count++;
+        if (!(range.range_flag & UNIQUE_RANGE) || (range.range_flag & NULL_RANGE) ||
+            !(range.range_flag & EQ_RANGE))
+        {
+            all_point = false;
+            break;
+        }
+    }
+
+    /* Only accept when there are multiple ranges.  For a single point lookup
+       the optimizer's eq_ref plan (plain index_read_map) is a better fit and
+       -- critically -- also the only path where pessimistic row locking
+       engages.  Accepting MRR for 1-range scans silently converts UPDATE
+       WHERE pk=v into a range scan that bypasses that lock. */
+    if (all_point && count >= 2)
+    {
+        /* Clear the default-impl flag so the server calls our init/next
+           instead of the fallback path. */
+        *mrr_mode &= ~HA_MRR_USE_DEFAULT_IMPL;
+        *bufsz = 0; /* we use our own std::vector, not HANDLER_BUFFER */
+    }
+    return rows;
+}
+
+/*
+  Build the sorted list of point lookups, or fall through to the default
+  impl if HA_MRR_USE_DEFAULT_IMPL is still set.  Sorting by comparable
+  bytes converts N scattered LSM seeks into a monotone stream -- much
+  friendlier to the block cache and the merge-heap.
+*/
+int ha_tidesdb::multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param, uint n_ranges,
+                                      uint mrr_mode, HANDLER_BUFFER *buf)
+{
+    DBUG_ENTER("ha_tidesdb::multi_range_read_init");
+
+    mrr_custom_active_ = !(mrr_mode & HA_MRR_USE_DEFAULT_IMPL);
+    if (!mrr_custom_active_)
+        DBUG_RETURN(handler::multi_range_read_init(seq, seq_init_param, n_ranges, mrr_mode, buf));
+
+    mrr_entries_.clear();
+    mrr_next_idx_ = 0;
+    mrr_keyno_ = active_index;
+    mrr_no_assoc_ = MY_TEST(mrr_mode & HA_MRR_NO_ASSOCIATION);
+    if (n_ranges > 0) mrr_entries_.reserve(n_ranges);
+
+    KEY *ki = &table->key_info[mrr_keyno_];
+
+    /* We need all columns readable while translating the caller's key_copy
+       bytes into our comparable format (key_copy_to_comparable calls
+       key_restore into record[1] and reads fields). */
+    MY_BITMAP *old_map = tmp_use_all_columns(table, &table->read_set);
+
+    KEY_MULTI_RANGE range;
+    range_seq_t it = seq->init(seq_init_param, n_ranges, mrr_mode);
+    while (!seq->next(it, &range))
+    {
+        uchar comp[MAX_KEY_LENGTH];
+        uint comp_len =
+            key_copy_to_comparable(ki, range.start_key.key, range.start_key.length, comp);
+
+        tdb_mrr_entry e;
+        e.comp_key.assign((const char *)comp, comp_len);
+        e.ptr = range.ptr;
+        mrr_entries_.push_back(std::move(e));
+    }
+
+    tmp_restore_column_map(&table->read_set, old_map);
+
+    std::sort(mrr_entries_.begin(), mrr_entries_.end(),
+              [](const tdb_mrr_entry &a, const tdb_mrr_entry &b)
+              { return a.comp_key < b.comp_key; });
+
+    DBUG_RETURN(0);
+}
+
+/*
+  Deliver the next row from the sorted list of point lookups.  PK lookups
+  bypass the iterator entirely via fetch_row_by_pk; secondary index lookups
+  reuse the cached scan iterator and a single seek per entry.  Rows that
+  the index knew about but the data CF no longer has (stale entries after
+  concurrent delete) are silently skipped.
+*/
+int ha_tidesdb::multi_range_read_next(range_id_t *range_info)
+{
+    DBUG_ENTER("ha_tidesdb::multi_range_read_next");
+
+    if (!mrr_custom_active_) DBUG_RETURN(handler::multi_range_read_next(range_info));
+
+    if (cached_thd_ && thd_killed(cached_thd_)) DBUG_RETURN(HA_ERR_ABORTED_BY_USER);
+
+    /* Lazy txn -- the optimizer may invoke MRR without a prior rnd_init / index_init. */
+    int erc = ensure_stmt_txn();
+    if (erc) DBUG_RETURN(erc);
+    if (!scan_txn) scan_txn = stmt_txn;
+
+    bool is_pk_scan = share->has_user_pk && mrr_keyno_ == share->pk_index;
+    uint idx_col_len = share->idx_comp_key_len[mrr_keyno_];
+
+    while (mrr_next_idx_ < mrr_entries_.size())
+    {
+        const tdb_mrr_entry &e = mrr_entries_[mrr_next_idx_++];
+        if (!mrr_no_assoc_) *range_info = e.ptr;
+
+        if (is_pk_scan)
+        {
+            int rc = fetch_row_by_pk(scan_txn, (const uchar *)e.comp_key.data(),
+                                     (uint)e.comp_key.size(), table->record[0]);
+            if (rc == HA_ERR_KEY_NOT_FOUND) continue; /* stale range, try next */
+            DBUG_RETURN(rc);
+        }
+
+        /* Secondary index point lookup -- seek, verify prefix match, then
+           either cover-read from the index or PK-fetch. */
+        if (mrr_keyno_ >= share->idx_cfs.size() || !share->idx_cfs[mrr_keyno_])
+            continue; /* missing CF for this index -- skip defensively */
+        scan_cf_ = share->idx_cfs[mrr_keyno_];
+        int irc = ensure_scan_iter();
+        if (irc) DBUG_RETURN(irc);
+
+        tidesdb_iter_seek(scan_iter, (const uint8_t *)e.comp_key.data(), (uint)e.comp_key.size());
+        if (!tidesdb_iter_valid(scan_iter)) continue;
+
+        uint8_t *ik = NULL;
+        size_t iks = 0;
+        if (tidesdb_iter_key(scan_iter, &ik, &iks) != TDB_SUCCESS) continue;
+        if (iks < e.comp_key.size() || memcmp(ik, e.comp_key.data(), e.comp_key.size()) != 0)
+            continue; /* no entry for this point */
+        if (iks <= idx_col_len) continue;
+
+        int rc;
+        if (keyread_only_ && try_keyread_from_index(ik, iks, mrr_keyno_, table->record[0]))
+            rc = 0;
+        else
+            rc = fetch_row_by_pk(scan_txn, ik + idx_col_len, (uint)(iks - idx_col_len),
+                                 table->record[0]);
+        if (rc == HA_ERR_KEY_NOT_FOUND) continue;
+        DBUG_RETURN(rc);
+    }
+
+    DBUG_RETURN(HA_ERR_END_OF_FILE);
 }
 
 /* ******************** info ******************** */

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -77,7 +77,7 @@ static int tdb_rc_to_ha(int rc, const char *ctx)
             if (unlikely(srv_print_all_conflicts))
             {
                 sql_print_information(
-                    "TIDESDB CONFLICT: %s: transaction aborted due to write-write "
+                    "[TIDESDB] %s: transaction aborted due to write-write "
                     "conflict (TDB_ERR_CONFLICT)",
                     ctx);
                 mysql_mutex_lock(&last_conflict_mutex);
@@ -282,7 +282,7 @@ static bool tdb_lock_would_deadlock(tidesdb_trx_t *requestor, tdb_row_lock_t *ta
   and removes the data races that the old code had when traversing pointers
   in unrelated partitions.
 */
-static int row_lock_acquire(tidesdb_trx_t *trx, const uchar *key, uint len)
+static int row_lock_acquire(tidesdb_trx_t *trx, const uchar *key, uint len, THD *thd)
 {
     if (!lock_partitions || !trx) return 0;
 
@@ -347,15 +347,30 @@ static int row_lock_acquire(tidesdb_trx_t *trx, const uchar *key, uint len)
         return 0;
     }
 
-    /* Still owned -- wait for release. */
+    /* Still owned -- wait for release.  kill_query wakes us by broadcasting
+       on lock->cond; we re-check thd_killed() on every wake-up and bail
+       with HA_ERR_LOCK_WAIT_TIMEOUT so the client sees a proper error
+       instead of hanging until the holder eventually commits. */
     lock->waiters++;
+    bool killed = false;
     while (lock->owner_txn_id.load(std::memory_order_relaxed) != 0 &&
            lock->owner_trx.load(std::memory_order_relaxed) != trx)
     {
+        if (thd && thd_killed(thd))
+        {
+            killed = true;
+            break;
+        }
         mysql_cond_wait(&lock->cond, &part->mutex);
     }
     lock->waiters--;
     trx->waiting_on.store(NULL, std::memory_order_relaxed);
+
+    if (killed)
+    {
+        mysql_mutex_unlock(&part->mutex);
+        return HA_ERR_LOCK_WAIT_TIMEOUT;
+    }
 
     /* We claim the lock */
     lock->owner_txn_id.store(trx->lock_txn_id, std::memory_order_release);
@@ -514,7 +529,7 @@ static constexpr uint FTS_TERM_LEN_PREFIX = 2;
 /* Worst-case FTS entry key buffer-- [2B term_len][term bytes][PK]. */
 static constexpr uint FTS_KEY_BUF_LEN = FTS_TERM_LEN_PREFIX + FTS_MAX_TERM_BYTES + MAX_KEY_LENGTH;
 
-/* FTS entry value layout: [2B tf LE][4B doc_len LE] = 6 bytes. */
+/* FTS entry value layout-- [2B tf LE][4B doc_len LE] = 6 bytes. */
 static constexpr uint FTS_VALUE_TF_LEN = 2;
 static constexpr uint FTS_VALUE_DOC_LEN_OFFSET = FTS_VALUE_TF_LEN;
 static constexpr uint FTS_VALUE_DOC_LEN_LEN = 4;
@@ -522,7 +537,7 @@ static constexpr uint FTS_VALUE_LEN = FTS_VALUE_TF_LEN + FTS_VALUE_DOC_LEN_LEN;
 
 /* FTS per-index meta key layout:
    [KEY_NS_META(1B)][FTS tag(4B incl NUL)][keynr(1B)] = 6 bytes.
-   Meta value layout: [8B total_docs][8B total_words] = 16 bytes. */
+   Meta value layout-- [8B total_docs][8B total_words] = 16 bytes. */
 static constexpr const char FTS_META_KEY_TAG[] = "FTS\x00";
 static constexpr uint FTS_META_KEY_TAG_LEN = 4; /* 3 letters + trailing NUL */
 static constexpr uint FTS_META_KEY_TAG_OFFSET = KEY_NAMESPACE_LEN;
@@ -558,7 +573,7 @@ static uint fts_build_value(uint16 tf, uint32 doc_len, uchar *out)
 }
 
 /* Read or initialize FTS metadata counters from the data CF.
-   Key format: [KEY_NS_META][FTS tag][keynr]. */
+   Key format-- [KEY_NS_META][FTS tag][keynr]. */
 static int fts_load_meta(tidesdb_txn_t *txn, tidesdb_column_family_t *data_cf, uint keynr,
                          int64_t *total_docs, int64_t *total_words)
 {
@@ -2991,6 +3006,53 @@ static void schema_cf_delete(const char *path)
 }
 
 /*
+  Remove every schema CF entry belonging to a dropped database.
+  Keys are "db_name\0table_name" so we iterate the CF and delete entries
+  whose prefix matches.  No-op in local-only mode (schema_cf is NULL).
+*/
+static void schema_cf_delete_db(const std::string &db_name)
+{
+    if (!schema_cf || db_name.empty()) return;
+
+    /* Match keys beginning with "db_name\0". */
+    std::string prefix = db_name;
+    prefix.push_back('\0');
+
+    tidesdb_txn_t *txn = NULL;
+    if (tidesdb_txn_begin(tdb_global, &txn) != TDB_SUCCESS) return;
+
+    tidesdb_iter_t *it = NULL;
+    if (tidesdb_iter_new(txn, schema_cf, &it) != TDB_SUCCESS)
+    {
+        tidesdb_txn_rollback(txn);
+        tidesdb_txn_free(txn);
+        return;
+    }
+
+    std::vector<std::string> to_delete;
+    tidesdb_iter_seek(it, (const uint8_t *)prefix.data(), prefix.size());
+    while (tidesdb_iter_valid(it))
+    {
+        uint8_t *k = NULL;
+        size_t klen = 0;
+        if (tidesdb_iter_key(it, &k, &klen) != TDB_SUCCESS) break;
+        if (klen < prefix.size() || memcmp(k, prefix.data(), prefix.size()) != 0) break;
+        to_delete.emplace_back((const char *)k, klen);
+        tidesdb_iter_next(it);
+    }
+    tidesdb_iter_free(it);
+
+    for (const auto &k : to_delete)
+        tidesdb_txn_delete(txn, schema_cf, (const uint8_t *)k.data(), k.size());
+
+    if (!to_delete.empty())
+        tidesdb_txn_commit(txn);
+    else
+        tidesdb_txn_rollback(txn);
+    tidesdb_txn_free(txn);
+}
+
+/*
   Rename a table's schema CF entry (delete old key, insert under new key).
   Called from rename_table().
 */
@@ -3251,6 +3313,11 @@ static void schema_cf_ensure_databases()
 /* ******************** Plugin init / deinit ******************** */
 
 static int tidesdb_hton_drop_table(handlerton *, const char *path);
+static void tidesdb_hton_drop_database(handlerton *, char *path);
+static bool tidesdb_hton_flush_logs(handlerton *);
+static int tidesdb_hton_panic(handlerton *, enum ha_panic_function flag);
+static void tidesdb_hton_pre_shutdown(void);
+static void tidesdb_hton_kill_query(handlerton *, THD *thd, enum thd_kill_levels level);
 
 static int tidesdb_init_func(void *p)
 {
@@ -3265,6 +3332,7 @@ static int tidesdb_init_func(void *p)
     tidesdb_hton->field_options = tidesdb_field_option_list;
     tidesdb_hton->index_options = tidesdb_index_option_list;
     tidesdb_hton->drop_table = tidesdb_hton_drop_table;
+    tidesdb_hton->drop_database = tidesdb_hton_drop_database;
 
     /* Handlerton transaction callbacks -- one TidesDB txn per BEGIN..COMMIT */
     tidesdb_hton->commit = tidesdb_commit;
@@ -3277,6 +3345,12 @@ static int tidesdb_init_func(void *p)
     tidesdb_hton->savepoint_release = tidesdb_savepoint_release;
     tidesdb_hton->start_consistent_snapshot = tidesdb_start_consistent_snapshot;
     tidesdb_hton->show_status = tidesdb_show_status;
+
+    /* Durability / lifecycle / cancellation hooks. */
+    tidesdb_hton->flush_logs = tidesdb_hton_flush_logs;
+    tidesdb_hton->panic = tidesdb_hton_panic;
+    tidesdb_hton->pre_shutdown = tidesdb_hton_pre_shutdown;
+    tidesdb_hton->kill_query = tidesdb_hton_kill_query;
 
     mysql_mutex_init(0, &last_conflict_mutex, MY_MUTEX_INIT_FAST);
 
@@ -3426,6 +3500,106 @@ static int tidesdb_init_func(void *p)
     DBUG_RETURN(0);
 }
 
+/*
+  Handlerton-level FLUSH LOGS callback.  Called on FLUSH LOGS and by
+  mariadb-backup before copying files so the on-disk WAL is a consistent
+  snapshot.  With unified-memtable mode one sync covers all CFs.  In
+  per-CF mode we sync the schema CF (always present in object-store
+  mode; otherwise we try the first registered CF).  Returns false on
+  success (handlerton convention).
+*/
+static bool tidesdb_hton_flush_logs(handlerton *)
+{
+    if (!tdb_global) return false;
+
+    tidesdb_column_family_t *target = schema_cf;
+    if (!target)
+    {
+        char **names = NULL;
+        int count = 0;
+        if (tidesdb_list_column_families(tdb_global, &names, &count) == TDB_SUCCESS && names)
+        {
+            if (count > 0 && names[0]) target = tidesdb_get_column_family(tdb_global, names[0]);
+            for (int i = 0; i < count; i++)
+                if (names[i]) free(names[i]);
+            free(names);
+        }
+    }
+    if (!target) return false; /* empty database -- nothing to sync */
+
+    int rc = tidesdb_sync_wal(target);
+    if (rc != TDB_SUCCESS)
+    {
+        sql_print_warning("[TIDESDB] flush_logs: tidesdb_sync_wal failed (rc=%d)", rc);
+        return true; /* error */
+    }
+    return false;
+}
+
+/*
+  Handlerton-level panic callback.  MariaDB calls this on signal-driven or
+  abnormal shutdown paths where tidesdb_deinit_func may not run.  We only
+  react to HA_PANIC_CLOSE -- the other flags are legacy ISAM-era.
+*/
+static int tidesdb_hton_panic(handlerton *, enum ha_panic_function flag)
+{
+    if (flag != HA_PANIC_CLOSE) return 0;
+    if (tdb_global)
+    {
+        tidesdb_close(tdb_global);
+        tdb_global = NULL;
+        schema_cf = NULL;
+    }
+    return 0;
+}
+
+/*
+  Handlerton-level pre_shutdown callback.  Runs before the deinit path so
+  background threads that still need a fully-functional server (compaction,
+  flush) get a clean signal to drain.  We flush the unified WAL synchronously
+  and let tidesdb_close() in deinit finish the teardown.
+*/
+static void tidesdb_hton_pre_shutdown(void)
+{
+    if (!tdb_global) return;
+
+    /* Sync the unified WAL so durability is preserved if deinit is racing
+       a forced exit.  The call is cheap when there's nothing to sync. */
+    (void)tidesdb_hton_flush_logs(tidesdb_hton);
+}
+
+/*
+  Handlerton-level kill_query callback.  MariaDB calls this when the user
+  runs KILL QUERY <id> or when the connection is killed.  Our job is to
+  wake the victim if it is currently blocked in row_lock_acquire so that
+  the wait loop observes thd_killed() and bails out promptly.
+
+  The trx's waiting_on pointer is the lock entry being waited on; a
+  broadcast on that entry's cond var wakes the waiter.  False wake-ups
+  are harmless -- the wait loop re-checks ownership and goes back to
+  sleep if the lock is still contended.
+*/
+static void tidesdb_hton_kill_query(handlerton *, THD *thd, enum thd_kill_levels)
+{
+    if (!thd) return;
+    tidesdb_trx_t *trx = (tidesdb_trx_t *)thd_get_ha_data(thd, tidesdb_hton);
+    if (!trx) return;
+
+    tdb_row_lock_t *wait = trx->waiting_on.load(std::memory_order_acquire);
+    if (!wait) return;
+
+    /* We broadcast under the owning partition's mutex so the wake-up is
+       serialized against the holder's release path.  Partition index is
+       cached on the lock entry so we don't have to recompute the hash. */
+    if (lock_partitions && wait->partition < ROW_LOCK_PARTITIONS)
+    {
+        tdb_lock_partition_t *part = &lock_partitions[wait->partition];
+        mysql_mutex_lock(&part->mutex);
+        mysql_cond_broadcast(&wait->cond);
+        mysql_mutex_unlock(&part->mutex);
+    }
+}
+
 static int tidesdb_deinit_func(void *p)
 {
     DBUG_ENTER("tidesdb_deinit_func");
@@ -3541,6 +3715,8 @@ ha_tidesdb::ha_tidesdb(handlerton *hton, TABLE_SHARE *table_arg)
       cached_trx_(NULL),
       trx_registered_(false),
       in_bulk_insert_(false),
+      in_bulk_update_(false),
+      in_bulk_delete_(false),
       bulk_insert_ops_(0),
       keyread_only_(false),
       write_can_replace_(false)
@@ -4937,7 +5113,7 @@ int ha_tidesdb::write_row(const uchar *buf)
        format used by index_read_map() for lock acquisition. */
     if (unlikely(srv_pessimistic_locking) && share->has_user_pk && trx)
     {
-        int lrc = row_lock_acquire(trx, pk, pk_len);
+        int lrc = row_lock_acquire(trx, pk, pk_len, cached_thd_);
         if (lrc)
         {
             tmp_restore_column_map(&table->read_set, old_map);
@@ -5153,49 +5329,11 @@ int ha_tidesdb::write_row(const uchar *buf)
         bulk_insert_ops_ += 1 + share->num_secondary_indexes;
         if (bulk_insert_ops_ >= TIDESDB_BULK_INSERT_BATCH_OPS)
         {
-            /* Mid-txn commit to stay under TDB_MAX_TXN_OPS and bound memory.
-               We use tidesdb_txn_reset() instead of free+recreate to preserve
-               the txn's internal buffers (ops array, arenas, CF arrays).
-               trx already cached at top of write_row. */
-            if (trx && trx->txn)
+            int mrc = maybe_bulk_commit(trx);
+            if (mrc)
             {
-                int crc = tidesdb_txn_commit(trx->txn);
-                if (crc != TDB_SUCCESS)
-                    sql_print_information("[TIDESDB] bulk insert mid-commit failed rc=%d", crc);
-                /* Reset reuses the txn with READ_COMMITTED -- bulk inserts
-                   don't need snapshot consistency across batches and higher
-                   levels would cause unbounded read-set growth. */
-                int rrc = tidesdb_txn_reset(trx->txn, TDB_ISOLATION_READ_COMMITTED);
-                if (rrc != TDB_SUCCESS)
-                {
-                    /* Reset failed -- we fall back to free+recreate */
-                    sql_print_warning(
-                        "[TIDESDB] bulk_insert tidesdb_txn_reset failed (rc=%d), "
-                        "falling back to free+begin",
-                        rrc);
-                    tidesdb_txn_free(trx->txn);
-                    trx->txn = NULL;
-                    crc = tidesdb_txn_begin_with_isolation(tdb_global, TDB_ISOLATION_READ_COMMITTED,
-                                                           &trx->txn);
-                    if (crc != TDB_SUCCESS)
-                    {
-                        tmp_restore_column_map(&table->read_set, old_map);
-                        DBUG_RETURN(tdb_rc_to_ha(crc, "bulk_insert txn_begin"));
-                    }
-                }
-                stmt_txn = trx->txn;
-                trx->txn_generation++;
-                /* Iterators depend on MERGE_SOURCE_TXN_OPS which are cleared
-                   by reset -- we invalidate all cached iterators. */
-                if (scan_iter)
-                {
-                    tidesdb_iter_free(scan_iter);
-                    scan_iter = NULL;
-                    scan_iter_cf_ = NULL;
-                    scan_iter_txn_ = NULL;
-                }
-                free_dup_iter_cache();
-                scan_txn = trx->txn;
+                tmp_restore_column_map(&table->read_set, old_map);
+                DBUG_RETURN(mrc);
             }
             bulk_insert_ops_ = 0;
         }
@@ -5242,6 +5380,30 @@ void ha_tidesdb::get_auto_increment(ulonglong offset, ulonglong increment,
     *nb_reserved_values = nb_desired_values;
 
     DBUG_VOID_RETURN;
+}
+
+/*
+  Reset the auto-increment counter(s) to the given value.  MariaDB's default
+  truncate() path calls this after delete_all_rows, and ALTER TABLE ...
+  AUTO_INCREMENT=N routes here as well.  The next auto-generated ID equals
+  `value` itself, so we store `value - 1` (get_auto_increment does
+  fetch-add and returns cur+1).  `value == 0` is the TRUNCATE case reset
+  to 1.  Hidden-PK row-id gets the same treatment for consistency.
+*/
+int ha_tidesdb::reset_auto_increment(ulonglong value)
+{
+    DBUG_ENTER("ha_tidesdb::reset_auto_increment");
+    if (!share) DBUG_RETURN(0);
+
+    ulonglong new_val = value > 0 ? value - 1 : 0;
+    share->auto_inc_val.store(new_val, std::memory_order_relaxed);
+
+    /* Hidden PK row-ids are one-based (delete_all_rows stores 1 for empty
+       tables).  Treat value==0 as "restart at 1". */
+    uint64_t new_rowid = value > 0 ? (uint64_t)value : 1;
+    share->next_row_id.store(new_rowid, std::memory_order_relaxed);
+
+    DBUG_RETURN(0);
 }
 
 /* ******************** Table scan (SELECT) ******************** */
@@ -5308,6 +5470,8 @@ int ha_tidesdb::rnd_end()
 int ha_tidesdb::rnd_next(uchar *buf)
 {
     DBUG_ENTER("ha_tidesdb::rnd_next");
+
+    if (cached_thd_ && thd_killed(cached_thd_)) DBUG_RETURN(HA_ERR_ABORTED_BY_USER);
 
     /* We advance past the last-read entry.  on the first call after rnd_init
      * the iterator is already positioned at the first data key by the seek
@@ -5501,7 +5665,7 @@ int ha_tidesdb::index_read_map(uchar *buf, const uchar *key, key_part_map keypar
                     tidesdb_trx_t *trx = cached_trx_;
                     if (trx)
                     {
-                        int lrc = row_lock_acquire(trx, comp_key, comp_len);
+                        int lrc = row_lock_acquire(trx, comp_key, comp_len, cached_thd_);
                         if (lrc) DBUG_RETURN(lrc);
                     }
                 }
@@ -5721,6 +5885,8 @@ int ha_tidesdb::index_next(uchar *buf)
 {
     DBUG_ENTER("ha_tidesdb::index_next");
 
+    if (cached_thd_ && thd_killed(cached_thd_)) DBUG_RETURN(HA_ERR_ABORTED_BY_USER);
+
     /* Spatial idx continuation */
     if (spatial_scan_active_)
     {
@@ -5798,6 +5964,8 @@ int ha_tidesdb::index_next(uchar *buf)
 int ha_tidesdb::index_prev(uchar *buf)
 {
     DBUG_ENTER("ha_tidesdb::index_prev");
+
+    if (cached_thd_ && thd_killed(cached_thd_)) DBUG_RETURN(HA_ERR_ABORTED_BY_USER);
 
     /* If PK exact match was done without iterator, create it now and
        seek to the matched key so that prev() steps before it. */
@@ -5941,6 +6109,8 @@ int ha_tidesdb::index_last(uchar *buf)
 int ha_tidesdb::index_next_same(uchar *buf, const uchar *key, uint keylen)
 {
     DBUG_ENTER("ha_tidesdb::index_next_same");
+
+    if (cached_thd_ && thd_killed(cached_thd_)) DBUG_RETURN(HA_ERR_ABORTED_BY_USER);
 
     /* Spatial index continuation */
     if (spatial_scan_active_)
@@ -6228,7 +6398,7 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
                     }
                 }
 
-                /* Meta: same doc stays, so delta_docs=0.  Word count shifts by
+                /* Meta same doc stays, so delta_docs=0.  Word count shifts by
                    new_wc - old_wc; only write the meta row when it actually
                    moved to avoid a pointless read-modify-write. */
                 int64_t wc_delta = (int64_t)new_wc - (int64_t)old_wc;
@@ -6332,6 +6502,26 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
 
     memcpy(current_pk_buf_, new_pk, new_pk_len);
     current_pk_len_ = new_pk_len;
+
+    /* Bulk UPDATE mid-txn commit.  Symmetric to write_row's bulk path.
+       One UPDATE op counts as 1 data put + 1 data delete (when PK changed)
+       + up to num_secondary_indexes entries rewritten.  We overestimate as
+       `1 + 2 * num_secondary_indexes` so the threshold fires earlier rather
+       than later and the txn never exceeds TDB_MAX_TXN_OPS. */
+    if (in_bulk_update_)
+    {
+        bulk_insert_ops_ += 1 + 2 * (ha_rows)share->num_secondary_indexes;
+        if (bulk_insert_ops_ >= TIDESDB_BULK_INSERT_BATCH_OPS)
+        {
+            int mrc = maybe_bulk_commit(trx);
+            if (mrc)
+            {
+                tmp_restore_column_map(&table->read_set, old_map);
+                DBUG_RETURN(mrc);
+            }
+            bulk_insert_ops_ = 0;
+        }
+    }
 
     /* Commit happens in external_lock(F_UNLCK). */
     tmp_restore_column_map(&table->read_set, old_map);
@@ -6453,6 +6643,23 @@ int ha_tidesdb::delete_row(const uchar *buf)
         }
     }
 
+    /* Bulk DELETE mid-txn commit-- 1 data delete + num_secondary_indexes
+       secondary-index deletes per row. */
+    if (in_bulk_delete_)
+    {
+        bulk_insert_ops_ += 1 + (ha_rows)share->num_secondary_indexes;
+        if (bulk_insert_ops_ >= TIDESDB_BULK_INSERT_BATCH_OPS)
+        {
+            int mrc = maybe_bulk_commit(trx);
+            if (mrc)
+            {
+                tmp_restore_column_map(&table->read_set, old_map);
+                DBUG_RETURN(mrc);
+            }
+            bulk_insert_ops_ = 0;
+        }
+    }
+
     tmp_restore_column_map(&table->read_set, old_map);
     DBUG_RETURN(0);
 }
@@ -6553,7 +6760,53 @@ int ha_tidesdb::delete_all_rows(void)
     DBUG_RETURN(0);
 }
 
-/* ******************** Bulk insert ******************** */
+/* ******************** Bulk DML ******************** */
+
+/*
+  Commit the current txn mid-statement and reset it with READ_COMMITTED so
+  the next batch starts fresh.  Shared by bulk INSERT/UPDATE/DELETE once
+  buffered ops cross TIDESDB_BULK_INSERT_BATCH_OPS -- keeps us under
+  TDB_MAX_TXN_OPS and bounds txn memory.  Higher isolation levels would
+  cause unbounded read-set growth across batches.
+
+  Any cached iterators and dup-check iterators are invalidated, they hold
+  references to MERGE_SOURCE_TXN_OPS that txn_reset clears.
+*/
+int ha_tidesdb::maybe_bulk_commit(tidesdb_trx_t *trx)
+{
+    if (!trx || !trx->txn) return 0;
+
+    int crc = tidesdb_txn_commit(trx->txn);
+    if (crc != TDB_SUCCESS) sql_print_information("[TIDESDB] bulk mid-commit failed rc=%d", crc);
+
+    int rrc = tidesdb_txn_reset(trx->txn, TDB_ISOLATION_READ_COMMITTED);
+    if (rrc != TDB_SUCCESS)
+    {
+        sql_print_warning(
+            "[TIDESDB] bulk tidesdb_txn_reset failed (rc=%d), falling back to "
+            "free+begin",
+            rrc);
+        tidesdb_txn_free(trx->txn);
+        trx->txn = NULL;
+        int rc =
+            tidesdb_txn_begin_with_isolation(tdb_global, TDB_ISOLATION_READ_COMMITTED, &trx->txn);
+        if (rc != TDB_SUCCESS) return tdb_rc_to_ha(rc, "bulk_commit txn_begin");
+    }
+
+    stmt_txn = trx->txn;
+    trx->txn_generation++;
+
+    if (scan_iter)
+    {
+        tidesdb_iter_free(scan_iter);
+        scan_iter = NULL;
+        scan_iter_cf_ = NULL;
+        scan_iter_txn_ = NULL;
+    }
+    free_dup_iter_cache();
+    scan_txn = trx->txn;
+    return 0;
+}
 
 void ha_tidesdb::start_bulk_insert(ha_rows rows, uint flags)
 {
@@ -6564,6 +6817,53 @@ void ha_tidesdb::start_bulk_insert(ha_rows rows, uint flags)
 int ha_tidesdb::end_bulk_insert()
 {
     in_bulk_insert_ = false;
+    return 0;
+}
+
+/*
+  start_bulk_update returns 0 when the engine will handle bulk batching.
+  We then flip the flag that update_row checks at its tail so every row
+  contributes to the shared ops counter.
+*/
+bool ha_tidesdb::start_bulk_update()
+{
+    in_bulk_update_ = true;
+    bulk_insert_ops_ = 0;
+    return 0;
+}
+
+int ha_tidesdb::end_bulk_update()
+{
+    in_bulk_update_ = false;
+    return 0;
+}
+
+/*
+  MariaDB calls bulk_update_row instead of update_row when start_bulk_update
+  returned 0.  We don't actually buffer rows (TidesDB's txn is the buffer);
+  we just delegate so the standard update_row path runs and its tail-side
+  mid-commit block batches.  dup_key_found tracks duplicate-key collisions
+  found in buffered-but-not-yet-applied rows -- since we apply immediately,
+  it's always zero.
+*/
+int ha_tidesdb::bulk_update_row(const uchar *old_data, const uchar *new_data,
+                                ha_rows *dup_key_found)
+{
+    DBUG_ENTER("ha_tidesdb::bulk_update_row");
+    if (dup_key_found) *dup_key_found = 0;
+    DBUG_RETURN(update_row(old_data, new_data));
+}
+
+bool ha_tidesdb::start_bulk_delete()
+{
+    in_bulk_delete_ = true;
+    bulk_insert_ops_ = 0;
+    return 0;
+}
+
+int ha_tidesdb::end_bulk_delete()
+{
+    in_bulk_delete_ = false;
     return 0;
 }
 
@@ -7292,6 +7592,8 @@ int ha_tidesdb::spatial_scan_next(uchar *buf)
 
         while (tidesdb_iter_valid(scan_iter))
         {
+            if (cached_thd_ && thd_killed(cached_thd_)) DBUG_RETURN(HA_ERR_ABORTED_BY_USER);
+
             uint8_t *ik = NULL;
             size_t iks = 0;
             if (tidesdb_iter_key(scan_iter, &ik, &iks) != TDB_SUCCESS) break;
@@ -7669,6 +7971,8 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
 int ha_tidesdb::ft_read(uchar *buf)
 {
     DBUG_ENTER("ha_tidesdb::ft_read");
+
+    if (cached_thd_ && thd_killed(cached_thd_)) DBUG_RETURN(HA_ERR_ABORTED_BY_USER);
 
     tdb_ft_info_t *info = reinterpret_cast<tdb_ft_info_t *>(ft_handler);
     if (!info)
@@ -8690,6 +8994,75 @@ static int tidesdb_drop_table_impl(const char *path)
 static int tidesdb_hton_drop_table(handlerton *, const char *path)
 {
     return tidesdb_drop_table_impl(path);
+}
+
+/*
+  Extract the database name from a directory path handed to drop_database.
+  The server passes something like "./test/" or "/var/lib/mysql/test/";
+  we strip trailing separators and return the final path component.
+*/
+static std::string tidesdb_path_to_db_name(const char *path)
+{
+    if (!path) return std::string();
+    std::string p(path);
+    while (!p.empty() && (p.back() == FN_LIBCHAR || p.back() == '/')) p.pop_back();
+    size_t slash = p.find_last_of("/\\");
+    if (slash != std::string::npos) p = p.substr(slash + 1);
+    return p;
+}
+
+/*
+  Handlerton-level drop_database callback.  MariaDB calls this when the
+  server-side DROP DATABASE has finished removing .frm files from the db
+  directory.  Without this hook, TidesDB column families whose .frm was
+  already unlinked (and any object-store-mode entries in schema_cf) would
+  outlive the database and accumulate on disk.
+
+  We enumerate every CF whose name starts with "<db_name>__" (the prefix
+  path_to_cf_name builds for a table in that database -- which also
+  captures all "db__tbl__idx_*" secondary-index CFs) and drop each.
+*/
+static void tidesdb_hton_drop_database(handlerton *, char *path)
+{
+    if (!tdb_global || !path) return;
+
+    std::string db = tidesdb_path_to_db_name(path);
+    if (db.empty()) return;
+
+    std::string prefix = db + "__";
+
+    std::vector<std::string> to_drop;
+    {
+        char **names = NULL;
+        int count = 0;
+        if (tidesdb_list_column_families(tdb_global, &names, &count) == TDB_SUCCESS && names)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if (!names[i]) continue;
+                if (strncmp(names[i], prefix.c_str(), prefix.size()) == 0)
+                    to_drop.emplace_back(names[i]);
+                free(names[i]);
+            }
+            free(names);
+        }
+    }
+
+    for (const auto &cf_name : to_drop)
+    {
+        int rc = tidesdb_drop_column_family(tdb_global, cf_name.c_str());
+        if (rc != TDB_SUCCESS && rc != TDB_ERR_NOT_FOUND)
+            sql_print_warning("[TIDESDB] drop_database: failed to drop CF '%s' (err=%d)",
+                              cf_name.c_str(), rc);
+        force_remove_cf_dir(cf_name);
+    }
+
+    /* Clean up schema CF entries for this database (object-store mode).
+       No-op when schema_cf is NULL (local-only mode). */
+    schema_cf_delete_db(db);
+
+    sql_print_information("[TIDESDB] drop_database: removed %zu column famil%s for '%s'",
+                          to_drop.size(), to_drop.size() == 1 ? "y" : "ies", db.c_str());
 }
 
 int ha_tidesdb::delete_table(const char *name)

--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -38,6 +38,24 @@ extern "C"
 static constexpr uint8_t KEY_NS_META = 0x00;
 static constexpr uint8_t KEY_NS_DATA = 0x01;
 
+/* Size of the namespace prefix that every TidesDB key starts with. */
+static constexpr uint KEY_NAMESPACE_LEN = 1;
+
+/* Buffer size for a data CF key, namespace byte + comparable PK + 1 byte slack.
+   Used by every site that builds KEY_NS_DATA + pk via build_data_key. */
+static constexpr uint DATA_KEY_BUF_LEN = KEY_NAMESPACE_LEN + MAX_KEY_LENGTH + 1;
+
+/* Buffer size for a secondary-index CF entry key, comparable index-column
+   bytes (up to MAX_KEY_LENGTH) + appended PK bytes (up to MAX_KEY_LENGTH)
+   + 2 bytes of slack that covers VARBINARY length-byte overflow emitted
+   by make_comparable_key. */
+static constexpr uint SEC_IDX_KEY_BUF_LEN = (MAX_KEY_LENGTH * 2) + 2;
+
+/* Number of doubles in a 2-D minimum bounding rectangle.  Always four
+   (xmin, ymin, xmax, ymax); used for the on-disk spatial value layout
+   and the in-memory query-MBR cache on the handler. */
+static constexpr uint SPATIAL_MBR_DIMS = 4;
+
 /* CF naming */
 static constexpr const char CF_INDEX_INFIX[] = "__idx_";
 
@@ -62,8 +80,23 @@ static constexpr long long TIDESDB_STATS_REFRESH_US = 2000000LL; /* 2 seconds */
 /* Minimum stats.records to avoid optimizer edge cases with 0 rows */
 static constexpr ha_rows TIDESDB_MIN_STATS_RECORDS = 2;
 
-/* Inplace index build batch commit size */
-static constexpr ha_rows TIDESDB_INDEX_BUILD_BATCH = 10000;
+/* scan_time() -- split the opaque cost returned by tidesdb_range_cost
+   between MariaDB's I/O and CPU cost buckets.  LSM scans are mostly
+   block-read bound, so 90% I/O / 10% CPU matches observed profiles. */
+static constexpr double TIDESDB_SCAN_IO_WEIGHT = 0.9;
+static constexpr double TIDESDB_SCAN_CPU_WEIGHT = 0.1;
+
+/* records_in_range() fallbacks when we can't get a useful estimate. */
+static constexpr ha_rows TIDESDB_RIR_DEFAULT_EST = 10;         /* no share available */
+static constexpr ha_rows TIDESDB_RIR_UNKNOWN_DENOM = 4;        /* total/4 + 1 quarter fallback */
+static constexpr double TIDESDB_RIR_FRACTION_UNRELIABLE = 0.8; /* fall back to rec_per_key */
+
+/* Inplace index build batch commit size.  Larger batches amortize the
+   commit+iter-recreate+seek cost that fires every batch boundary (see
+   inplace_alter_table -- each batch boundary does a free+reset txn and
+   re-seeks to last_data_key, which is O(merge-heap) per seek).  50k
+   matches TIDESDB_BULK_INSERT_BATCH_OPS and keeps txn memory bounded. */
+static constexpr ha_rows TIDESDB_INDEX_BUILD_BATCH = 50000;
 
 /* Bulk insert mid-txn commit threshold (ops, not rows) */
 static constexpr ha_rows TIDESDB_BULK_INSERT_BATCH_OPS = 50000;
@@ -124,6 +157,11 @@ class TidesDB_share : public Handler_share
     uint num_secondary_indexes; /* count of non-NULL secondary index CFs */
     size_t cached_row_est{0};   /* cached serialize_row size estimate for non-BLOB tables */
 
+    /* Field indices of BLOB/TEXT columns -- populated at open() when
+       has_blobs is true.  serialize_row iterates only these instead of
+       scanning all fields for the BLOB_FLAG. */
+    std::vector<uint16> blob_field_indices;
+
     /* Cached scan_time range cost (refreshed every TIDESDB_STATS_REFRESH_US) */
     std::atomic<double> cached_scan_cost{0.0};
     std::atomic<long long> scan_cost_time{0};
@@ -144,6 +182,12 @@ class TidesDB_share : public Handler_share
     /* Precomputed comparable key length per index (avoids per-row recomputation) */
     uint idx_comp_key_len[MAX_KEY];
 
+    /* Precomputed index-type flags (avoid ki->algorithm dereference per row
+       in DML secondary-index loops).  Populated at open() and refreshed
+       during online DDL. */
+    bool idx_is_fts[MAX_KEY];
+    bool idx_is_spatial[MAX_KEY];
+
     /* Cached rec_per_key for secondary indexes (populated by ANALYZE TABLE).
        0 = not yet computed, use heuristic; >0 = sampled value. */
     std::atomic<ulong> cached_rec_per_key[MAX_KEY];
@@ -151,6 +195,14 @@ class TidesDB_share : public Handler_share
     /* Secondary index CFs (one per secondary key) */
     std::vector<tidesdb_column_family_t *> idx_cfs;
     std::vector<std::string> idx_cf_names;
+
+    /* Per-index covered-field map used by try_keyread_from_index.  For each
+       index i, idx_cover[i][field_c] == true when field `c` can be
+       reconstructed from the index key bytes (i.e. field is in the index's
+       key parts or -- for secondary indexes -- in the PK parts appended
+       to the key).  Replaces the O(read_set_bits * (pk_parts + idx_parts))
+       nested scan the old code did on every covered read. */
+    std::vector<std::vector<bool>> idx_cover;
 
     TidesDB_share();
     ~TidesDB_share();
@@ -202,8 +254,11 @@ struct tidesdb_trx_t
 
     struct tdb_row_lock_t *held_locks_head; /* singly-linked list of held lock entries */
     uint64_t lock_txn_id; /* unique ID for deadlock detection (= txn_generation) */
-    struct tdb_row_lock_t
-        *waiting_on; /* lock entry we're currently blocked on (NULL if not waiting) */
+    /* `waiting_on` is read by other threads during deadlock graph walks (from
+       arbitrary partitions) without holding this trx's partition mutex.
+       Atomic access guarantees the reader sees a published pointer value and
+       never a torn write. */
+    std::atomic<struct tdb_row_lock_t *> waiting_on;
 };
 
 /*
@@ -241,9 +296,9 @@ class ha_tidesdb : public handler
     {
         HA_READ_KEY_EXACT
     };
-    double spatial_qmbr_[4]{}; /* query MBR: xmin, ymin, xmax, ymax */
+    double spatial_qmbr_[SPATIAL_MBR_DIMS]{}; /* query MBR (xmin, ymin, xmax, ymax) */
 
-    /* Hilbert range decomposition: sorted non-overlapping [lo, hi] ranges
+    /* Hilbert range decomposition are sorted non-overlapping [lo, hi] ranges
        covering the query box.  spatial_range_idx_ tracks which range we're
        currently scanning. */
     std::vector<std::pair<uint64_t, uint64_t>> spatial_ranges_; /* {lo, hi} */
@@ -266,8 +321,8 @@ class ha_tidesdb : public handler
 
     /* Reusable buffers for secondary index key construction in update_row.
        Avoids heap allocation per row and keeps the stack frame small. */
-    uchar upd_old_ik_[MAX_KEY_LENGTH * 2 + 2];
-    uchar upd_new_ik_[MAX_KEY_LENGTH * 2 + 2];
+    uchar upd_old_ik_[SEC_IDX_KEY_BUF_LEN];
+    uchar upd_new_ik_[SEC_IDX_KEY_BUF_LEN];
 
     /* Cached dup-check iterators for UNIQUE secondary indexes.
        tidesdb_iter_new() is O(num_sstables) -- caching avoids rebuilding
@@ -305,6 +360,42 @@ class ha_tidesdb : public handler
        Used to decide whether to acquire row locks in index_read_map. */
     bool stmt_has_write_lock_;
 
+    /* Cached "is this scan on the primary key" flag.  Set once in index_init
+       so the navigation methods (index_next/prev/first/last/next_same) skip
+       the per-row `share->has_user_pk && active_index == share->pk_index`
+       recomputation. */
+    bool is_pk_;
+
+    /* Cached last tidesdb_iter_new failure for the current scan CF/txn.
+       When non-zero and the scan_cf_/scan_txn haven't changed, ensure_scan_iter
+       returns the prior error immediately instead of retrying + re-logging. */
+    int scan_iter_last_err_;
+    tidesdb_column_family_t *scan_iter_last_err_cf_;
+    tidesdb_txn_t *scan_iter_last_err_txn_;
+
+    /* Handler mirrors of share->has_blobs / share->encrypted.  Per-row
+       fetches and scans branch on these; reading them from a handler member
+       avoids the shared-memory dereference that dominates when the L1 line
+       for `share` isn't already hot. */
+    bool has_blobs_;
+    bool encrypted_;
+
+    /* Cached bounds of table->record[1] so the BLOB path of fetch_row_by_pk
+       and iter_read_current can classify `buf` against record[0] vs record[1]
+       without dereferencing `table->record[1]` and `table->s->reclength` on
+       every row. */
+    const uchar *record1_lo_;
+    const uchar *record1_hi_;
+
+    /* Cached per-statement THD query shape so ensure_stmt_txn() and
+       external_lock() don't each re-evaluate thd_sql_command() and
+       thd_test_options().  Populated by external_lock(F_WRLCK/F_RDLCK);
+       invalidated by external_lock(F_UNLCK) along with the other per-stmt
+       caches. */
+    int cached_sql_cmd_;
+    bool cached_is_autocommit_;
+    bool cached_stmt_shape_valid_;
+
     /* Cached per-statement pointers to avoid repeated hash lookups.
        Set in external_lock(lock), cleared in external_lock(F_UNLCK).
        InnoDB caches these as m_user_thd / m_prebuilt->trx. */
@@ -341,8 +432,8 @@ class ha_tidesdb : public handler
     static uint build_data_key(const uchar *pk, uint pk_len, uchar *out)
     {
         out[0] = KEY_NS_DATA;
-        memcpy(out + 1, pk, pk_len);
-        return pk_len + 1;
+        memcpy(out + KEY_NAMESPACE_LEN, pk, pk_len);
+        return pk_len + KEY_NAMESPACE_LEN;
     }
 
     /* Build a secondary-index entry key into out[]; returns byte count */
@@ -376,8 +467,9 @@ class ha_tidesdb : public handler
     check_result_t icp_check_secondary(const uint8_t *ik, size_t iks, uint idx, uchar *buf);
 
     /* Reverse a single integer sort-key part back to native little-endian
-       field format.  Returns true on success, false for unsupported types. */
-    static bool decode_int_sort_key(const uint8_t *src, uint sort_len, Field *f, uchar *buf);
+       at `to` (destination byte pointer computed once by the caller).
+       Returns true on success, false for unsupported sort_len. */
+    static bool decode_int_sort_key(const uint8_t *src, uint sort_len, bool is_signed, uchar *to);
 
     /* Extended sort-key decoder -- handles integers, DATE, DATETIME,
        TIMESTAMP, YEAR, and fixed-length CHAR/BINARY.  Returns true on

--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -403,8 +403,12 @@ class ha_tidesdb : public handler
     tidesdb_trx_t *cached_trx_; /* avoids thd_get_ha_data() hash lookup */
     bool trx_registered_;       /* true once trans_register_ha() called this txn */
 
-    /* Bulk insert state */
+    /* Bulk DML state.  The ops counter is shared across insert/update/delete
+       bulk modes since only one can be active at a time and they all use the
+       same TIDESDB_BULK_INSERT_BATCH_OPS threshold. */
     bool in_bulk_insert_;
+    bool in_bulk_update_;
+    bool in_bulk_delete_;
     ha_rows bulk_insert_ops_; /* ops buffered since last mid-txn commit */
 
     /* Covering-index mode (HA_EXTRA_KEYREAD) */
@@ -479,6 +483,12 @@ class ha_tidesdb : public handler
 
     /* Free all cached dup-check iterators */
     void free_dup_iter_cache();
+
+    /* Commit the current txn mid-statement when a bulk op crosses the batch
+       threshold, then reset it to READ_COMMITTED for the next batch.  Shared
+       between bulk INSERT/UPDATE/DELETE.  Invalidates cached iterators.
+       Returns 0 on success, handler error code on fatal failure. */
+    int maybe_bulk_commit(tidesdb_trx_t *trx);
 
     /* Recover hidden-PK counter by scanning the CF */
     void recover_counters();
@@ -588,12 +598,28 @@ class ha_tidesdb : public handler
     void start_bulk_insert(ha_rows rows, uint flags) override;
     int end_bulk_insert() override;
 
+    /* Bulk UPDATE / DELETE hints -- let multi-row UPDATE/DELETE share the
+       same mid-txn commit batching as bulk INSERT so long statements don't
+       blow past TDB_MAX_TXN_OPS or balloon txn memory. */
+    bool start_bulk_update() override;
+    int end_bulk_update() override;
+    int bulk_update_row(const uchar *old_data, const uchar *new_data,
+                        ha_rows *dup_key_found) override;
+    bool start_bulk_delete() override;
+    int end_bulk_delete() override;
+
     /* Index Condition Pushdown (ICP) */
     Item *idx_cond_push(uint keyno, Item *idx_cond) override;
 
     /* AUTO_INCREMENT -- O(1) atomic counter */
     void get_auto_increment(ulonglong offset, ulonglong increment, ulonglong nb_desired_values,
                             ulonglong *first_value, ulonglong *nb_reserved_values) override;
+
+    /* Reset the in-memory auto-increment counter so `TRUNCATE TABLE t` and
+       `ALTER TABLE t AUTO_INCREMENT=N` take effect.  Base default is a no-op,
+       which left TidesDB's cached counter running past TRUNCATE -- the next
+       INSERT would return a stale value instead of restarting at 1 (or N). */
+    int reset_auto_increment(ulonglong value) override;
 
     /* Stats / Maintenance */
     int info(uint flag) override;

--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -411,6 +411,22 @@ class ha_tidesdb : public handler
     bool in_bulk_delete_;
     ha_rows bulk_insert_ops_; /* ops buffered since last mid-txn commit */
 
+    /* Multi-Range Read state.  We accept MRR when every range the optimizer
+       hands us is UNIQUE_RANGE|EQ_RANGE (i.e. the WHERE col IN (...) case on
+       a full key) and fall back to the default MRR->read_range_first path for
+       everything else.  Accepted ranges are buffered + sorted by comparable
+       key bytes so the LSM sees a monotone stream of seeks. */
+    struct tdb_mrr_entry
+    {
+        std::string comp_key; /* comparable PK / index bytes */
+        range_id_t ptr;       /* value returned to caller as *range_info */
+    };
+    bool mrr_custom_active_;
+    bool mrr_no_assoc_;
+    uint mrr_keyno_;
+    std::vector<tdb_mrr_entry> mrr_entries_;
+    size_t mrr_next_idx_;
+
     /* Covering-index mode (HA_EXTRA_KEYREAD) */
     bool keyread_only_;
     bool write_can_replace_; /* true during REPLACE INTO (HA_EXTRA_WRITE_CAN_REPLACE) */
@@ -610,6 +626,16 @@ class ha_tidesdb : public handler
 
     /* Index Condition Pushdown (ICP) */
     Item *idx_cond_push(uint keyno, Item *idx_cond) override;
+
+    /* Multi-Range Read (MRR).  We opt into a custom implementation for
+       point-only range sequences and defer to the base handler for
+       everything else by leaving HA_MRR_USE_DEFAULT_IMPL set. */
+    ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq, void *seq_init_param,
+                                        uint n_ranges, uint *bufsz, uint *mrr_mode, ha_rows limit,
+                                        Cost_estimate *cost) override;
+    int multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param, uint n_ranges, uint mrr_mode,
+                              HANDLER_BUFFER *buf) override;
+    int multi_range_read_next(range_id_t *range_info) override;
 
     /* AUTO_INCREMENT -- O(1) atomic counter */
     void get_auto_increment(ulonglong offset, ulonglong increment, ulonglong nb_desired_values,


### PR DESCRIPTION
reduce per-row overhead in DML, scan, FTS, spatial, and locking paths

A batch of targeted optimizations across ha_tidesdb removing redundant
work from the row-level hot paths. No behavior changes.

DML secondary-index maintenance
-------------------------------

Consolidate the three separate passes in update_row (regular / FTS / spatial)
and delete_row (regular / FTS / spatial) into one dispatch loop per method.
write_row's maintenance loop was already consolidated.

Cache TidesDB_share::idx_is_fts[MAX_KEY] and idx_is_spatial[MAX_KEY], populated
in open() and on commit_inplace_alter_table. The old code called
is_fts_index() / is_spatial_index() (each a ki->algorithm dereference) two or
three times per secondary index per row.

Add a write_set pre-check to the regular-index branch of update_row so
unchanged indexes skip both make_comparable_key and sec_idx_key entirely. FTS
and spatial already did this; the regular branch used to build both the old
and new keys just to memcmp them.

Scan-path invariants
--------------------

Cache is_pk_ on the handler in index_init() so index_next / index_prev /
index_first / index_last / index_next_same / index_read_map don't each
recompute share->has_user_pk && active_index == share->pk_index.

Mirror share->has_blobs and share->encrypted onto the handler as has_blobs_ /
encrypted_ so fetch_row_by_pk and iter_read_current read from local members
instead of chasing share into shared memory on every row fetched.

Precompute table->record[1] bounds as record1_lo_ / record1_hi_ in open(); the
BLOB-classification path now does two pointer compares per row instead of
rebuilding the range (table->record[1] plus table->s->reclength dereferences)
each time.

Cache scan_iter creation failure (scan_iter_last_err_ plus the CF/txn it
applies to) so a failed tidesdb_iter_new isn't retried and re-logged by every
subsequent navigation call within the same statement.

Transaction & locking
---------------------

external_lock now resolves thd_sql_command() and thd_test_options() once per
statement into cached_sql_cmd_ / cached_is_autocommit_ /
cached_stmt_shape_valid_; ensure_stmt_txn and the F_UNLCK branch read the
cache instead of re-evaluating. Eliminates four redundant THD probes per
statement.

Pessimistic row-lock deadlock detection: tdb_row_lock_t::owner_txn_id and
owner_trx, and tidesdb_trx_t::waiting_on, are now std::atomic<>.
row_lock_acquire publishes waiting_on under the partition mutex, drops the
mutex, runs tdb_lock_would_deadlock with explicit acquire loads, re-acquires
the mutex, and re-checks state (claiming the lock directly if the owner
released during the walk).

This corrects two issues the previous code had:

  1. holding the partition mutex across a graph walk of up to
     DEADLOCK_MAX_DEPTH=100 hops blocked every other locker on that partition
     for the duration; and
  2. the walk read owner_trx / waiting_on from OTHER partitions without
     synchronization. Lock entries are never freed and trx structs live for
     the lifetime of the connection, so pointer stability was fine, but the
     reads themselves were technically data races.

Added sql_print_warning on tidesdb_txn_reset failures in get_or_create_trx, the
write_row bulk-insert mid-commit path, and the online DDL batch path.
Previously these silently fell through to free+begin, hiding any regression
in txn recycling behind a quieter but slower path.

FTS
---

fts_tokenize now holds tdb_stopword_lock for the duration of one tokenize
call instead of acquiring and releasing it per emitted token. A 1000-word doc
previously took 1000 rwlock pairs on the write path; now takes one.
tdb_is_stopword is renamed tdb_is_stopword_locked to document the
precondition.

update_row FTS branch switched from 'delete every old term + put every new
term' to a term-level diff: tokenize old and new into tf maps, then delete
only disappeared terms and put only new/changed-tf terms. When doc_len
changed, every surviving term is re-put (doc_len is in the BM25 value).
PK-change falls back to the full replace since the key includes the PK.
Collapsed the two fts_update_meta(-1, -old_wc) / (+1, +new_wc) calls into one
(0, new_wc - old_wc); skip entirely when the delta is zero.

Hoist tokenization out of the phrase-verification loop in ft_init_ext.
Extracted fts_phrase_in_tokens(doc_tokens, phrase_words) and dropped the
now-unused fts_verify_phrase. Each candidate is tokenized once; all phrases
check against that vector. Previously: N candidates * M phrases
tokenizations.

Precompute inv_avgdl = 1.0 / avgdl once and multiply in the BM25 posting loop
instead of dividing per posting.

Spatial
-------

Add a DBUG_ASSERT in wkb_parse_geometry that the leading byte-order byte
matches the host's native endianness. The parser does native memcpy reads of
the geometry type and coordinates downstream; if MariaDB ever stored
non-native WKB, release builds would silently return garbage MBRs while debug
builds would now trip the assert.

ICP / covering index
--------------------

decode_sort_key_part computes `to = buf + (f->ptr - f->table->record[0])` once
at function entry and shares it across all branches, which used to each
recompute the same offset. decode_int_sort_key signature changed to take
(is_signed, to) directly instead of (Field*, buf).

try_keyread_from_index no longer does nested iteration over PK + index key
parts per read-set bit. TidesDB_share now carries idx_cover[key_num] as a
vector<bool> sized to table->s->fields, populated at open() and on
commit_inplace_alter_table. Covered-read column check is O(set bits in
read_set) with a direct lookup per bit.


Online DDL
----------

Bump TIDESDB_INDEX_BUILD_BATCH from 10,000 to 50,000 (same as
TIDESDB_BULK_INSERT_BATCH_OPS). The inplace-index-build loop commits every
batch, frees and recreates the iterator, and seeks to last_data_key; larger
batches cut the seek count ~5x.

Misc / cleanup
--------------

share->blob_field_indices (vector<uint16>) collected at open(); the
serialize_row size-estimate loop on BLOB tables now iterates just that list
instead of scanning every field for BLOB_FLAG per INSERT.

Clean up magic strings and numbers across code base with consistent constants.
