### PR TITLE
issue #115 mariadb 12.3.1 (MDEV-37815) renamed TABLE_SHARE::option_st…

### DIFF
--- a/README
+++ b/README
@@ -24,6 +24,10 @@ To skip storage engines you don't need (saves build time and reduces warnings):
 ./install.sh --list-engines                       # see what can be skipped
 ./install.sh --skip-engines mroonga,rocksdb,connect,spider,oqgraph,columnstore
 
+To use specific MariaDB version: --mariadb-version mariadb-12.3.1 aligning to https://github.com/MariaDB/server/releases/tag/mariadb-12.2.2
+
+When using install script you are installing the latest version of TideSQL at the time of clone or download.
+
 To link libtidesdb against a non-default allocator (jemalloc is a common
 pick for write-heavy workloads):
 

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -43,10 +43,12 @@ extern "C"
 #include "sql_class.h"
 #include "sql_priv.h"
 
-/* MariaDB 12.3 moved option_struct from TABLE_SHARE to TABLE (MDEV-37815).
-   We provide a compat macro so the same code compiles on 11.x / 12.0-12.2 / 12.3+. */
-#if MYSQL_VERSION_ID >= 120300
-#define TDB_TABLE_OPTIONS(tbl) ((tbl)->option_struct)
+/* MariaDB 12.3.1 (MDEV-37815) renamed TABLE_SHARE::option_struct to
+   option_struct_table and introduced handler::option_struct as the preferred
+   accessor.  We keep reading from TABLE_SHARE so the macro works from
+   create(), inplace alter, and free functions that only have a TABLE*. */
+#if MYSQL_VERSION_ID >= 120301
+#define TDB_TABLE_OPTIONS(tbl) ((tbl)->s->option_struct_table)
 #else
 #define TDB_TABLE_OPTIONS(tbl) ((tbl)->s->option_struct)
 #endif
@@ -9282,8 +9284,8 @@ static long long srv_stat_cache_misses;
 static double srv_stat_cache_hit_rate;
 static long long srv_stat_cache_partitions;
 
-#define TIDESQL_VERSION_STR "4.2.5"
-#define TIDESQL_VERSION_HEX 0x40205
+#define TIDESQL_VERSION_STR "4.2.6"
+#define TIDESQL_VERSION_HEX 0x40206
 
 static const char *srv_stat_version = TIDESQL_VERSION_STR;
 static long long srv_stat_version_hex = TIDESQL_VERSION_HEX;


### PR DESCRIPTION
issue #115  mariadb 12.3.1 (MDEV-37815) renamed TABLE_SHARE::option_struct to option_struct_table and introduced handler::option_struct as the preferred accessor, addition of conditional handling; also updated read me to further explain semantics of install script mariadb-version flag and version used when installing of tidesql base