### PR TITLE
TideSQL MINOR (v4.3.0)

### DIFF
--- a/mysql-test/suite/tidesdb/r/tidesdb_fts_blend_chars.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_fts_blend_chars.result
@@ -45,6 +45,8 @@ id
 5
 # Stop word through blend: the (still filtered)
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('the');
+COUNT(*)
+0
 # Boolean mode with blend chars
 SELECT id FROM docs WHERE MATCH(body) AGAINST("+aria -malley" IN BOOLEAN MODE) ORDER BY id;
 id

--- a/mysql-test/suite/tidesdb/r/tidesdb_fts_stopwords.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_fts_stopwords.result
@@ -14,15 +14,35 @@ INSERT INTO docs (body) VALUES
 ('The cat sat on the mat by the door');
 # Stop words should return 0 rows
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('the');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('is');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('a');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('of');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('in');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('on');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('by');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('with');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('for');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('this');
+COUNT(*)
+0
 # Real words should return matches
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('fox');
 COUNT(*)
@@ -66,7 +86,11 @@ INSERT INTO docs (body) VALUES
 ('Building bridges for the future of our community');
 # Stop words still filtered for new rows
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('the');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('is');
+COUNT(*)
+0
 # Real words from new rows work
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('beautiful');
 COUNT(*)
@@ -77,6 +101,8 @@ COUNT(*)
 # UPDATE should maintain stop word filtering
 UPDATE docs SET body = 'The revised document about the important topic' WHERE id = 1;
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('the');
+COUNT(*)
+0
 SELECT COUNT(*) FROM docs WHERE MATCH(body) AGAINST('revised');
 COUNT(*)
 1

--- a/mysql-test/suite/tidesdb/r/tidesdb_single_delete.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_single_delete.result
@@ -1,0 +1,226 @@
+#
+# === sysvar: default is OFF ===
+#
+SHOW VARIABLES LIKE 'tidesdb_single_delete_primary';
+Variable_name	Value
+tidesdb_single_delete_primary	OFF
+SELECT @@SESSION.tidesdb_single_delete_primary;
+@@SESSION.tidesdb_single_delete_primary
+0
+#
+# === Secondary-index single-delete is always on (no flag needed). ===
+# Reads must remain correct across INSERT, SELECT, UPDATE, DELETE on a
+# table with multiple secondary indexes.  This exercises update_row's
+# old-entry delete path and delete_row's secondary-index dispatch loop.
+#
+CREATE TABLE t_sec (
+pk BIGINT PRIMARY KEY,
+c0 INT,
+c1 INT,
+c2 INT,
+KEY k0 (c0),
+KEY k1 (c1),
+KEY k2 (c2)
+) ENGINE=TIDESDB;
+INSERT INTO t_sec VALUES (1,10,100,1000),(2,20,200,2000),(3,30,300,3000);
+SELECT * FROM t_sec ORDER BY pk;
+pk	c0	c1	c2
+1	10	100	1000
+2	20	200	2000
+3	30	300	3000
+SELECT pk FROM t_sec WHERE c0 = 20;
+pk
+2
+SELECT pk FROM t_sec WHERE c1 = 300;
+pk
+3
+SELECT pk FROM t_sec WHERE c2 = 1000;
+pk
+1
+UPDATE t_sec SET c0 = 11, c1 = 111 WHERE pk = 1;
+SELECT * FROM t_sec ORDER BY pk;
+pk	c0	c1	c2
+1	11	111	1000
+2	20	200	2000
+3	30	300	3000
+SELECT pk FROM t_sec WHERE c0 = 10;
+pk
+SELECT pk FROM t_sec WHERE c0 = 11;
+pk
+1
+SELECT pk FROM t_sec WHERE c1 = 100;
+pk
+SELECT pk FROM t_sec WHERE c1 = 111;
+pk
+1
+DELETE FROM t_sec WHERE pk = 2;
+SELECT * FROM t_sec ORDER BY pk;
+pk	c0	c1	c2
+1	11	111	1000
+3	30	300	3000
+SELECT pk FROM t_sec WHERE c0 = 20;
+pk
+SELECT pk FROM t_sec WHERE c1 = 200;
+pk
+DELETE FROM t_sec;
+SELECT COUNT(*) FROM t_sec;
+COUNT(*)
+0
+#
+# REPLACE INTO on a table with secondary indexes: the server routes
+# through delete_row + write_row, so each specific (col_vals, pk) is
+# still put-once-delete-once.  Secondary-index single-delete stays
+# safe.
+#
+INSERT INTO t_sec VALUES (5,50,500,5000);
+REPLACE INTO t_sec VALUES (5,55,555,5555);
+SELECT * FROM t_sec WHERE pk = 5;
+pk	c0	c1	c2
+5	55	555	5555
+SELECT pk FROM t_sec WHERE c0 = 50;
+pk
+SELECT pk FROM t_sec WHERE c0 = 55;
+pk
+5
+DROP TABLE t_sec;
+#
+# === Primary-CF single-delete under the sysvar: insert-then-delete. ===
+# The contract holds because we only INSERT and DELETE -- no UPDATE,
+# no REPLACE.  Reads must agree with the non-sysvar baseline.
+#
+SET SESSION tidesdb_single_delete_primary = 1;
+SELECT @@SESSION.tidesdb_single_delete_primary;
+@@SESSION.tidesdb_single_delete_primary
+1
+CREATE TABLE t_pri (
+pk BIGINT PRIMARY KEY,
+v  VARCHAR(32)
+) ENGINE=TIDESDB;
+INSERT INTO t_pri VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e');
+SELECT * FROM t_pri ORDER BY pk;
+pk	v
+1	a
+2	b
+3	c
+4	d
+5	e
+DELETE FROM t_pri WHERE pk IN (2,4);
+SELECT * FROM t_pri ORDER BY pk;
+pk	v
+1	a
+3	c
+5	e
+DELETE FROM t_pri;
+SELECT COUNT(*) FROM t_pri;
+COUNT(*)
+0
+#
+# Insert a fresh batch, delete every row, read nothing back.  This
+# matches the iibench-shaped workload.
+#
+INSERT INTO t_pri VALUES (10,'x'),(20,'y'),(30,'z'),(40,'w'),(50,'v');
+SELECT COUNT(*) FROM t_pri;
+COUNT(*)
+5
+DELETE FROM t_pri;
+SELECT COUNT(*) FROM t_pri;
+COUNT(*)
+0
+DROP TABLE t_pri;
+#
+# === Primary-CF single-delete with secondary indexes present. ===
+# Secondary-index SD is already unconditional; primary-CF SD is gated
+# on the sysvar.  Together they cover all four CFs per delete on
+# Mark's num_secondary_indexes=3 table shape.
+#
+CREATE TABLE t_mark (
+transactionid BIGINT PRIMARY KEY,
+c0 INT,
+c1 INT,
+c2 INT,
+KEY (c0),
+KEY (c1),
+KEY (c2)
+) ENGINE=TIDESDB;
+INSERT INTO t_mark VALUES (1,10,100,1000),(2,20,200,2000),(3,30,300,3000),
+(4,40,400,4000),(5,50,500,5000);
+SELECT COUNT(*) FROM t_mark;
+COUNT(*)
+5
+SELECT transactionid FROM t_mark WHERE c1 = 300;
+transactionid
+3
+DELETE FROM t_mark WHERE transactionid >= 2 ORDER BY transactionid ASC LIMIT 2;
+SELECT transactionid FROM t_mark ORDER BY transactionid;
+transactionid
+1
+4
+5
+SELECT transactionid FROM t_mark WHERE c0 = 20;
+transactionid
+SELECT transactionid FROM t_mark WHERE c2 = 3000;
+transactionid
+DELETE FROM t_mark;
+SELECT COUNT(*) FROM t_mark;
+COUNT(*)
+0
+DROP TABLE t_mark;
+SET SESSION tidesdb_single_delete_primary = 0;
+#
+# === Sysvar OFF across UPDATE + REPLACE paths (safety baseline). ===
+# Any workload that uses UPDATE non-PK / REPLACE INTO on no-secondary
+# tables must stay correct with the sysvar OFF, because primary-CF SD
+# is unsafe under those patterns.  Secondary-index SD is independent
+# of the sysvar.
+#
+CREATE TABLE t_upd (
+pk BIGINT PRIMARY KEY,
+c0 INT,
+KEY (c0)
+) ENGINE=TIDESDB;
+INSERT INTO t_upd VALUES (1,100),(2,200),(3,300);
+UPDATE t_upd SET c0 = 999 WHERE pk = 2;
+SELECT * FROM t_upd ORDER BY pk;
+pk	c0
+1	100
+2	999
+3	300
+SELECT pk FROM t_upd WHERE c0 = 200;
+pk
+SELECT pk FROM t_upd WHERE c0 = 999;
+pk
+2
+DELETE FROM t_upd WHERE pk = 2;
+SELECT * FROM t_upd ORDER BY pk;
+pk	c0
+1	100
+3	300
+SELECT pk FROM t_upd WHERE c0 = 999;
+pk
+DROP TABLE t_upd;
+#
+# REPLACE INTO on a no-secondary table follows the line-5143 "overwrite
+# silently" fast path.  With sysvar OFF (default), subsequent DELETEs
+# remain correct because the regular tombstone is used.
+#
+CREATE TABLE t_rep (
+pk BIGINT PRIMARY KEY,
+v  VARCHAR(32)
+) ENGINE=TIDESDB;
+INSERT INTO t_rep VALUES (1,'first');
+REPLACE INTO t_rep VALUES (1,'second');
+SELECT * FROM t_rep;
+pk	v
+1	second
+DELETE FROM t_rep WHERE pk = 1;
+SELECT COUNT(*) FROM t_rep;
+COUNT(*)
+0
+SELECT * FROM t_rep;
+pk	v
+INSERT INTO t_rep VALUES (1,'third');
+SELECT * FROM t_rep;
+pk	v
+1	third
+DROP TABLE t_rep;
+# Done.

--- a/mysql-test/suite/tidesdb/t/tidesdb_single_delete.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_single_delete.test
@@ -1,0 +1,200 @@
+--source include/have_tidesdb.inc
+#
+# Test coverage for the tidesdb_single_delete_primary session variable
+# and the unconditional single-delete semantics on secondary-index CFs.
+#
+# The single-delete contract is "at most one put between single-deletes
+# on the same key".  Secondary-index CFs satisfy that by construction
+# for every (col_values, pk) composite and use single-delete on every
+# delete path automatically.  The primary CF only satisfies the
+# contract when the session does no UPDATE on non-PK columns and no
+# REPLACE INTO / INSERT ... ON DUPLICATE KEY UPDATE overwrite path on
+# tables without secondary indexes -- the session variable is the
+# caller's explicit promise.
+#
+
+--echo #
+--echo # === sysvar: default is OFF ===
+--echo #
+
+SHOW VARIABLES LIKE 'tidesdb_single_delete_primary';
+SELECT @@SESSION.tidesdb_single_delete_primary;
+
+--echo #
+--echo # === Secondary-index single-delete is always on (no flag needed). ===
+--echo # Reads must remain correct across INSERT, SELECT, UPDATE, DELETE on a
+--echo # table with multiple secondary indexes.  This exercises update_row's
+--echo # old-entry delete path and delete_row's secondary-index dispatch loop.
+--echo #
+
+CREATE TABLE t_sec (
+  pk BIGINT PRIMARY KEY,
+  c0 INT,
+  c1 INT,
+  c2 INT,
+  KEY k0 (c0),
+  KEY k1 (c1),
+  KEY k2 (c2)
+) ENGINE=TIDESDB;
+
+INSERT INTO t_sec VALUES (1,10,100,1000),(2,20,200,2000),(3,30,300,3000);
+
+SELECT * FROM t_sec ORDER BY pk;
+SELECT pk FROM t_sec WHERE c0 = 20;
+SELECT pk FROM t_sec WHERE c1 = 300;
+SELECT pk FROM t_sec WHERE c2 = 1000;
+
+UPDATE t_sec SET c0 = 11, c1 = 111 WHERE pk = 1;
+
+SELECT * FROM t_sec ORDER BY pk;
+SELECT pk FROM t_sec WHERE c0 = 10;
+SELECT pk FROM t_sec WHERE c0 = 11;
+SELECT pk FROM t_sec WHERE c1 = 100;
+SELECT pk FROM t_sec WHERE c1 = 111;
+
+DELETE FROM t_sec WHERE pk = 2;
+
+SELECT * FROM t_sec ORDER BY pk;
+SELECT pk FROM t_sec WHERE c0 = 20;
+SELECT pk FROM t_sec WHERE c1 = 200;
+
+DELETE FROM t_sec;
+SELECT COUNT(*) FROM t_sec;
+
+--echo #
+--echo # REPLACE INTO on a table with secondary indexes: the server routes
+--echo # through delete_row + write_row, so each specific (col_vals, pk) is
+--echo # still put-once-delete-once.  Secondary-index single-delete stays
+--echo # safe.
+--echo #
+
+INSERT INTO t_sec VALUES (5,50,500,5000);
+REPLACE INTO t_sec VALUES (5,55,555,5555);
+SELECT * FROM t_sec WHERE pk = 5;
+SELECT pk FROM t_sec WHERE c0 = 50;
+SELECT pk FROM t_sec WHERE c0 = 55;
+
+DROP TABLE t_sec;
+
+--echo #
+--echo # === Primary-CF single-delete under the sysvar: insert-then-delete. ===
+--echo # The contract holds because we only INSERT and DELETE -- no UPDATE,
+--echo # no REPLACE.  Reads must agree with the non-sysvar baseline.
+--echo #
+
+SET SESSION tidesdb_single_delete_primary = 1;
+SELECT @@SESSION.tidesdb_single_delete_primary;
+
+CREATE TABLE t_pri (
+  pk BIGINT PRIMARY KEY,
+  v  VARCHAR(32)
+) ENGINE=TIDESDB;
+
+INSERT INTO t_pri VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e');
+SELECT * FROM t_pri ORDER BY pk;
+
+DELETE FROM t_pri WHERE pk IN (2,4);
+SELECT * FROM t_pri ORDER BY pk;
+
+DELETE FROM t_pri;
+SELECT COUNT(*) FROM t_pri;
+
+--echo #
+--echo # Insert a fresh batch, delete every row, read nothing back.  This
+--echo # matches the iibench-shaped workload.
+--echo #
+
+INSERT INTO t_pri VALUES (10,'x'),(20,'y'),(30,'z'),(40,'w'),(50,'v');
+SELECT COUNT(*) FROM t_pri;
+DELETE FROM t_pri;
+SELECT COUNT(*) FROM t_pri;
+
+DROP TABLE t_pri;
+
+--echo #
+--echo # === Primary-CF single-delete with secondary indexes present. ===
+--echo # Secondary-index SD is already unconditional; primary-CF SD is gated
+--echo # on the sysvar.  Together they cover all four CFs per delete on
+--echo # Mark's num_secondary_indexes=3 table shape.
+--echo #
+
+CREATE TABLE t_mark (
+  transactionid BIGINT PRIMARY KEY,
+  c0 INT,
+  c1 INT,
+  c2 INT,
+  KEY (c0),
+  KEY (c1),
+  KEY (c2)
+) ENGINE=TIDESDB;
+
+INSERT INTO t_mark VALUES (1,10,100,1000),(2,20,200,2000),(3,30,300,3000),
+                          (4,40,400,4000),(5,50,500,5000);
+SELECT COUNT(*) FROM t_mark;
+SELECT transactionid FROM t_mark WHERE c1 = 300;
+
+DELETE FROM t_mark WHERE transactionid >= 2 ORDER BY transactionid ASC LIMIT 2;
+SELECT transactionid FROM t_mark ORDER BY transactionid;
+SELECT transactionid FROM t_mark WHERE c0 = 20;
+SELECT transactionid FROM t_mark WHERE c2 = 3000;
+
+DELETE FROM t_mark;
+SELECT COUNT(*) FROM t_mark;
+
+DROP TABLE t_mark;
+
+SET SESSION tidesdb_single_delete_primary = 0;
+
+--echo #
+--echo # === Sysvar OFF across UPDATE + REPLACE paths (safety baseline). ===
+--echo # Any workload that uses UPDATE non-PK / REPLACE INTO on no-secondary
+--echo # tables must stay correct with the sysvar OFF, because primary-CF SD
+--echo # is unsafe under those patterns.  Secondary-index SD is independent
+--echo # of the sysvar.
+--echo #
+
+CREATE TABLE t_upd (
+  pk BIGINT PRIMARY KEY,
+  c0 INT,
+  KEY (c0)
+) ENGINE=TIDESDB;
+
+INSERT INTO t_upd VALUES (1,100),(2,200),(3,300);
+
+UPDATE t_upd SET c0 = 999 WHERE pk = 2;
+SELECT * FROM t_upd ORDER BY pk;
+SELECT pk FROM t_upd WHERE c0 = 200;
+SELECT pk FROM t_upd WHERE c0 = 999;
+
+DELETE FROM t_upd WHERE pk = 2;
+SELECT * FROM t_upd ORDER BY pk;
+SELECT pk FROM t_upd WHERE c0 = 999;
+
+DROP TABLE t_upd;
+
+--echo #
+--echo # REPLACE INTO on a no-secondary table follows the line-5143 "overwrite
+--echo # silently" fast path.  With sysvar OFF (default), subsequent DELETEs
+--echo # remain correct because the regular tombstone is used.
+--echo #
+
+CREATE TABLE t_rep (
+  pk BIGINT PRIMARY KEY,
+  v  VARCHAR(32)
+) ENGINE=TIDESDB;
+
+INSERT INTO t_rep VALUES (1,'first');
+REPLACE INTO t_rep VALUES (1,'second');
+SELECT * FROM t_rep;
+
+DELETE FROM t_rep WHERE pk = 1;
+SELECT COUNT(*) FROM t_rep;
+SELECT * FROM t_rep;
+
+INSERT INTO t_rep VALUES (1,'third');
+SELECT * FROM t_rep;
+
+DROP TABLE t_rep;
+
+--source suite/tidesdb/include/cleanup_tidesdb.inc
+--echo # Done.

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -142,6 +142,24 @@ static int tdb_rc_to_ha(int rc, const char *ctx)
     }
 }
 
+/*
+  Dispatch to tidesdb_txn_single_delete or tidesdb_txn_delete based on
+  use_single_delete.  Secondary-index delete sites pass true because the
+  single-delete contract (at most one put between single-deletes on the
+  same key) holds by construction for (col_values, pk) / (term, pk) /
+  (hilbert, pk) composites.  Primary-CF delete sites pass the cached
+  value of the tidesdb_single_delete_primary session variable, which
+  defaults off and is the caller's explicit promise that the session
+  does no UPDATE on non-PK columns and no REPLACE INTO / IODKU overwrite
+  path on no-secondary tables.
+*/
+static inline int tidesdb_txn_delete_cf(tidesdb_txn_t *txn, tidesdb_column_family_t *cf,
+                                        const uint8_t *key, size_t key_size, bool use_single_delete)
+{
+    return use_single_delete ? tidesdb_txn_single_delete(txn, cf, key, key_size)
+                             : tidesdb_txn_delete(txn, cf, key, key_size);
+}
+
 /* MariaDB data directory */
 extern MYSQL_PLUGIN_IMPORT char mysql_real_data_home[];
 
@@ -1592,6 +1610,29 @@ static MYSQL_THDVAR_BOOL(skip_unique_check, PLUGIN_VAR_RQCMDARG,
                          "SET SESSION tidesdb_skip_unique_check=1",
                          NULL, NULL, 0);
 
+/* Per-session opt-in for single-delete semantics on the primary row CF.
+   Secondary-index deletes always use tidesdb_txn_single_delete because
+   each (col_values, pk) / (term, pk) / (hilbert, pk) composite is written
+   exactly once per row lifetime and deleted exactly once -- the
+   single-delete contract holds unconditionally for those.
+   For the primary CF the contract is narrower: UPDATE ... SET non_pk_col
+   writes tidesdb_txn_put(share->cf, data_key(pk), ...) with the same PK,
+   producing a put-over-put, and REPLACE INTO / INSERT ... ON DUPLICATE
+   KEY UPDATE on tables with no secondary indexes does the same via a
+   silent overwrite.  Under either pattern, dropping a put+single-delete
+   pair at compaction can re-expose an older put.  Enabling this variable
+   is the caller's promise that the session does none of the above --
+   typical insert-then-delete, log-style, append-only workloads. */
+static MYSQL_THDVAR_BOOL(single_delete_primary, PLUGIN_VAR_RQCMDARG,
+                         "Use single-delete semantics for the primary row CF on DELETE. "
+                         "Caller promises no UPDATE on non-PK columns, no REPLACE INTO, "
+                         "and no INSERT ... ON DUPLICATE KEY UPDATE on tables without "
+                         "secondary indexes for this session.  Violating the contract may "
+                         "re-expose older row versions after compaction.  Safe choice: "
+                         "leave OFF unless the session is INSERT-and-DELETE only.  "
+                         "SET SESSION tidesdb_single_delete_primary=1",
+                         NULL, NULL, 0);
+
 /* Session-level defaults for table options.
    These are used by HA_TOPTION_SYSVAR so that CREATE TABLE without
    explicit options inherits the session/global default.  Dynamic and
@@ -1687,13 +1728,13 @@ static MYSQL_THDVAR_ULONGLONG(default_min_disk_space, PLUGIN_VAR_RQCMDARG,
 static MYSQL_THDVAR_BOOL(default_object_lazy_compaction, PLUGIN_VAR_RQCMDARG,
                          "Default object store lazy compaction for new tables. "
                          "When enabled, doubles the L1 file count compaction trigger "
-                         "to reduce remote I/O at the cost of higher read amplification.",
+                         "to reduce remote I/O at the cost of higher read amplification",
                          NULL, NULL, 0);
 
 static MYSQL_THDVAR_BOOL(default_object_prefetch_compaction, PLUGIN_VAR_RQCMDARG,
                          "Default object store prefetch compaction for new tables. "
                          "When enabled, downloads all input SSTables in parallel "
-                         "before compaction merge begins.",
+                         "before compaction merge begins",
                          NULL, NULL, 1);
 
 static const char *isolation_level_names[] = {
@@ -1779,7 +1820,7 @@ static MYSQL_SYSVAR_STR(fts_blend_chars, srv_fts_blend_chars,
                         "individual parts. For example, with blend_chars=\"'\" the input "
                         "\"l'aria\" produces tokens: l'aria, aria. "
                         "Set to \"'\" for Italian/French elision support. "
-                        "Default is empty (no blend characters).",
+                        "Default is empty (no blend characters)",
                         NULL, tdb_fts_blend_chars_update, NULL);
 
 static MYSQL_SYSVAR_STR(ft_stopword_table, srv_ft_stopword_table,
@@ -1788,7 +1829,7 @@ static MYSQL_SYSVAR_STR(ft_stopword_table, srv_ft_stopword_table,
                         "The table must have a VARCHAR column named 'value'. "
                         "When NULL (default), uses the same 36 default stop words as "
                         "information_schema.INNODB_FT_DEFAULT_STOPWORD. "
-                        "Set to empty string to disable stop word filtering entirely.",
+                        "Set to empty string to disable stop word filtering entirely",
                         NULL, tdb_ft_stopword_table_update, NULL);
 
 static MYSQL_SYSVAR_ULONGLONG(block_cache_size, srv_block_cache_size,
@@ -2116,6 +2157,7 @@ static struct st_mysql_sys_var *tidesdb_system_variables[] = {
     MYSQL_SYSVAR(data_home_dir),
     MYSQL_SYSVAR(ttl),
     MYSQL_SYSVAR(skip_unique_check),
+    MYSQL_SYSVAR(single_delete_primary),
     MYSQL_SYSVAR(default_compression),
     MYSQL_SYSVAR(default_write_buffer_size),
     MYSQL_SYSVAR(default_bloom_filter),
@@ -3700,6 +3742,7 @@ ha_tidesdb::ha_tidesdb(handlerton *hton, TABLE_SHARE *table_arg)
       cached_time_valid_(false),
       cached_sess_ttl_(0),
       cached_skip_unique_(false),
+      cached_single_delete_primary_(false),
       cached_thdvars_valid_(false),
       stmt_has_write_lock_(false),
       is_pk_(false),
@@ -5132,6 +5175,7 @@ int ha_tidesdb::write_row(const uchar *buf)
     {
         cached_skip_unique_ = THDVAR(cached_thd_, skip_unique_check);
         cached_sess_ttl_ = THDVAR(cached_thd_, ttl);
+        cached_single_delete_primary_ = THDVAR(cached_thd_, single_delete_primary);
         cached_thdvars_valid_ = true;
     }
 
@@ -6258,6 +6302,7 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
     {
         cached_skip_unique_ = THDVAR(cached_thd_, skip_unique_check);
         cached_sess_ttl_ = THDVAR(cached_thd_, ttl);
+        cached_single_delete_primary_ = THDVAR(cached_thd_, single_delete_primary);
         cached_thdvars_valid_ = true;
     }
 
@@ -6274,7 +6319,8 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
     {
         uchar old_dk[DATA_KEY_BUF_LEN];
         uint old_dk_len = build_data_key(old_pk, old_pk_len, old_dk);
-        rc = tidesdb_txn_delete(txn, share->cf, old_dk, old_dk_len);
+        rc = tidesdb_txn_delete_cf(txn, share->cf, old_dk, old_dk_len,
+                                   cached_single_delete_primary_);
         if (rc != TDB_SUCCESS) goto err;
     }
 
@@ -6349,7 +6395,7 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
                         uchar fk[FTS_KEY_BUF_LEN];
                         uint fk_len =
                             fts_build_key(term.data(), (uint)term.size(), old_pk, old_pk_len, fk);
-                        tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
+                        tidesdb_txn_delete_cf(txn, share->idx_cfs[i], fk, fk_len, true);
                     }
                     for (auto &[term, tf] : new_tf)
                     {
@@ -6377,7 +6423,7 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
                         uchar fk[FTS_KEY_BUF_LEN];
                         uint fk_len =
                             fts_build_key(term.data(), (uint)term.size(), old_pk, old_pk_len, fk);
-                        tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
+                        tidesdb_txn_delete_cf(txn, share->idx_cfs[i], fk, fk_len, true);
                     }
 
                     for (auto &[term, new_cnt] : new_tf)
@@ -6432,7 +6478,7 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
                         uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
                         uint sk_len = spatial_build_key((xmn + xmx) / 2.0, (ymn + ymx) / 2.0,
                                                         old_pk, old_pk_len, sk);
-                        tidesdb_txn_delete(txn, share->idx_cfs[i], sk, sk_len);
+                        tidesdb_txn_delete_cf(txn, share->idx_cfs[i], sk, sk_len, true);
                     }
                 }
 
@@ -6497,7 +6543,7 @@ int ha_tidesdb::update_row(const uchar *old_data, const uchar *new_data)
                 /* Skip if the final index bytes match (e.g. UPDATE x=x). */
                 if (old_ik_len == new_ik_len && memcmp(old_ik, new_ik, old_ik_len) == 0) continue;
 
-                rc = tidesdb_txn_delete(txn, share->idx_cfs[i], old_ik, old_ik_len);
+                rc = tidesdb_txn_delete_cf(txn, share->idx_cfs[i], old_ik, old_ik_len, true);
                 if (rc != TDB_SUCCESS) goto err;
                 rc = tidesdb_txn_put(txn, share->idx_cfs[i], new_ik, new_ik_len, &tdb_empty_val, 1,
                                      row_ttl);
@@ -6552,6 +6598,17 @@ int ha_tidesdb::delete_row(const uchar *buf)
     /* Row locks are acquired in index_read_map() during the preceding
        locking read -- see update_row() comment. */
 
+    /* We populate THDVAR cache if not yet done this statement.  A pure DELETE
+       reaches delete_row without first going through write_row/update_row, so
+       the cache may still be stale from the prior statement. */
+    if (!cached_thdvars_valid_)
+    {
+        cached_skip_unique_ = THDVAR(cached_thd_, skip_unique_check);
+        cached_sess_ttl_ = THDVAR(cached_thd_, ttl);
+        cached_single_delete_primary_ = THDVAR(cached_thd_, single_delete_primary);
+        cached_thdvars_valid_ = true;
+    }
+
     {
         int erc = ensure_stmt_txn();
         if (erc)
@@ -6571,7 +6628,7 @@ int ha_tidesdb::delete_row(const uchar *buf)
     /* We delete data row */
     uchar dk[DATA_KEY_BUF_LEN];
     uint dk_len = build_data_key(current_pk_buf_, current_pk_len_, dk);
-    int rc = tidesdb_txn_delete(txn, share->cf, dk, dk_len);
+    int rc = tidesdb_txn_delete_cf(txn, share->cf, dk, dk_len, cached_single_delete_primary_);
     if (rc != TDB_SUCCESS)
     {
         tmp_restore_column_map(&table->read_set, old_map);
@@ -6609,7 +6666,7 @@ int ha_tidesdb::delete_row(const uchar *buf)
                     uchar fk[FTS_KEY_BUF_LEN];
                     uint fk_len = fts_build_key(term.data(), (uint)term.size(), current_pk_buf_,
                                                 current_pk_len_, fk);
-                    tidesdb_txn_delete(txn, share->idx_cfs[i], fk, fk_len);
+                    tidesdb_txn_delete_cf(txn, share->idx_cfs[i], fk, fk_len, true);
                 }
 
                 fts_update_meta(txn, share->cf, i, -1, -(int64_t)word_count);
@@ -6632,14 +6689,14 @@ int ha_tidesdb::delete_row(const uchar *buf)
                     double cy = (ymin + ymax) / 2.0;
                     uchar sk[SPATIAL_HILBERT_KEY_LEN + MAX_KEY_LENGTH];
                     uint sk_len = spatial_build_key(cx, cy, current_pk_buf_, current_pk_len_, sk);
-                    tidesdb_txn_delete(txn, share->idx_cfs[i], sk, sk_len);
+                    tidesdb_txn_delete_cf(txn, share->idx_cfs[i], sk, sk_len, true);
                 }
             }
             else
             {
                 uchar ik[SEC_IDX_KEY_BUF_LEN];
                 uint ik_len = sec_idx_key(i, buf, ik);
-                rc = tidesdb_txn_delete(txn, share->idx_cfs[i], ik, ik_len);
+                rc = tidesdb_txn_delete_cf(txn, share->idx_cfs[i], ik, ik_len, true);
                 if (rc != TDB_SUCCESS)
                 {
                     tmp_restore_column_map(&table->read_set, old_map);
@@ -7913,7 +7970,26 @@ FT_INFO *ha_tidesdb::ft_init_ext(uint flags, uint inx, String *key)
         }
     }
 
-    if (query_terms.empty()) DBUG_RETURN(NULL);
+    /* A query that tokenises down to nothing (e.g. all stop words, all
+       characters below the min-word-len threshold) still has to return a
+       usable FT_INFO, not NULL.  The server's execution path assumes an
+       FT_INFO was handed back and leaves the diagnostics area in an
+       inconsistent state when ft_init_ext yields NULL for reasons other
+       than an outright error; debug builds trip Protocol::end_statement's
+       DBUG_ASSERT(0).  We return an empty result set instead, which the
+       optimizer folds into zero matched rows. */
+    if (query_terms.empty())
+    {
+        tdb_ft_info_t *empty = new tdb_ft_info_t();
+        empty->please = const_cast<_ft_vft *>(&tdb_ft_vft);
+        empty->could_you = &tdb_ft_vft_ext;
+        empty->handler = this;
+        empty->keynr = inx;
+        empty->current_idx = 0;
+        empty->current_rank = 0.0f;
+        empty->match_count = 0;
+        DBUG_RETURN(reinterpret_cast<FT_INFO *>(empty));
+    }
 
     /* We load BM25 global metadata */
     int64_t total_docs = 0, total_words = 0;
@@ -9284,8 +9360,8 @@ static long long srv_stat_cache_misses;
 static double srv_stat_cache_hit_rate;
 static long long srv_stat_cache_partitions;
 
-#define TIDESQL_VERSION_STR "4.2.6"
-#define TIDESQL_VERSION_HEX 0x40206
+#define TIDESQL_VERSION_STR "4.3.0"
+#define TIDESQL_VERSION_HEX 0x40300
 
 static const char *srv_stat_version = TIDESQL_VERSION_STR;
 static long long srv_stat_version_hex = TIDESQL_VERSION_HEX;

--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -91,15 +91,14 @@ static constexpr ha_rows TIDESDB_RIR_DEFAULT_EST = 10;         /* no share avail
 static constexpr ha_rows TIDESDB_RIR_UNKNOWN_DENOM = 4;        /* total/4 + 1 quarter fallback */
 static constexpr double TIDESDB_RIR_FRACTION_UNRELIABLE = 0.8; /* fall back to rec_per_key */
 
-/* Inplace index build batch commit size.  Larger batches amortize the
-   commit+iter-recreate+seek cost that fires every batch boundary (see
-   inplace_alter_table -- each batch boundary does a free+reset txn and
-   re-seeks to last_data_key, which is O(merge-heap) per seek).  50k
-   matches TIDESDB_BULK_INSERT_BATCH_OPS and keeps txn memory bounded. */
-static constexpr ha_rows TIDESDB_INDEX_BUILD_BATCH = 50000;
+/* Inplace index builds rows between mid-txn commits and between
+   thd_killed polls. */
+static constexpr ha_rows TIDESDB_INDEX_BUILD_BATCH = 100;
 
-/* Bulk insert mid-txn commit threshold (ops, not rows) */
-static constexpr ha_rows TIDESDB_BULK_INSERT_BATCH_OPS = 50000;
+/* Bulk DML ops between mid-txn commits during start_bulk_insert /
+   start_bulk_update / start_bulk_delete.  Counts both the primary put
+   and each secondary-index put. */
+static constexpr ha_rows TIDESDB_BULK_INSERT_BATCH_OPS = 500;
 
 /* Encryption */
 static constexpr uint TIDESDB_ENC_IV_LEN = 16;

--- a/tidesdb/ha_tidesdb.h
+++ b/tidesdb/ha_tidesdb.h
@@ -354,6 +354,7 @@ class ha_tidesdb : public handler
        thd_get_ha_data + offset computation on every row. */
     ulonglong cached_sess_ttl_;
     bool cached_skip_unique_;
+    bool cached_single_delete_primary_;
     bool cached_thdvars_valid_;
 
     /* Write-lock mode -- set when store_lock detects FOR UPDATE / write intent.


### PR DESCRIPTION
added session variable tidesdb_single_delete_primary default off defined contract no update on non pk no replace into no insert on duplicate key update on no secondary tables violations may expose older versions after compaction

added cached_single_delete_primary_ to thdvar cache populated in write_row update_row and delete_row
added cache refresh in delete_row for pure delete path

added helper tidesdb_txn_delete_cf to dispatch delete vs single delete based on bool placed near tdb_rc_to_ha with safety notes

rewired delete sites to use helper

gated primary cf delete_row and update_row old pk delete on pk change on cached_single_delete_primary_

updated secondary fts spatial and regular delete paths to use single delete unconditionally safe by construction since each composite key written once and deleted once

left schema cf deletes alter add index and truncate as regular delete

bumped version from 4.2.6 to 4.3.0

added mysql tests for single delete

covered sysvar default and toggle
covered secondary index single delete across insert update delete replace covered primary cf single delete under sysvar on insert delete workload covered iibench shaped workload with transactionid and secondary indexes covered safety baseline with sysvar off

forced sstable separation via flush between batches in tests

fixed debug build issues found by asan

removed trailing period from sysvar descriptions to satisfy assert

fixed ft_init_ext returning null for empty match against returned empty result object instead

updated fts test results for correct empty output

this minor really puts attention on issue #122 