### PR TITLE
align column family LSM level defaults to the library and pin them

### DIFF
--- a/README
+++ b/README
@@ -484,7 +484,7 @@ family configuration.  ALTER TABLE ... <option>=<value> updates both the .frm
 and the live column family via tidesdb_cf_update_runtime_config().
 
 Storage:
-  WRITE_BUFFER_SIZE         Memtable size before flush (default: 128MB)
+  WRITE_BUFFER_SIZE         Memtable size before flush (default: 64MB PER TABLE/CF)
   MIN_DISK_SPACE            Minimum free disk space (default: 100MB)
   KLOG_VALUE_THRESHOLD      Values larger than this go to vlog (default: 512)
 
@@ -506,8 +506,8 @@ Isolation:
 LSM Tree:
   USE_BTREE                 Use B+tree SSTable format (default: OFF)
   LEVEL_SIZE_RATIO          Level size multiplier (default: 10)
-  MIN_LEVELS                Minimum LSM levels (default: 5)
-  DIVIDING_LEVEL_OFFSET     Compaction dividing level offset (default: 2)
+  MIN_LEVELS                Minimum LSM levels (default: 1, matches library)
+  DIVIDING_LEVEL_OFFSET     Compaction dividing level offset (default: 1, matches library)
   L1_FILE_COUNT_TRIGGER     L1 file count trigger for compaction (default: 4)
   L0_QUEUE_STALL_THRESHOLD  L0 queue stall threshold (default: 20)
   TOMBSTONE_DENSITY_TRIGGER Ratio in parts per 10000 above which compaction
@@ -540,6 +540,37 @@ Encryption:
   ENCRYPTION_KEY_ID         Encryption key ID (default: 1)
 
 
+DEFAULTS ALIGNMENT WITH THE LIBRARY
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+
+The column-family option defaults track tidesdb_default_column_family_config
+in the underlying TidesDB library 1:1 except for three deliberate
+deviations chosen to fit SQL semantics and a typical OLTP server
+profile.  tidesdb_defaults_alignment in the MTR suite pins every
+default so a future change has to be made deliberately.
+
+  SYNC_MODE          plugin FULL, library NONE.  SQL clients expect
+                     committed writes to be durable.  Only the per CF
+                     SSTable sync is affected since the shared WAL is
+                     governed by tidesdb_unified_memtable_sync_mode.
+  ISOLATION_LEVEL    plugin REPEATABLE_READ, library READ_COMMITTED.
+                     Matches MariaDB's default session isolation so a
+                     plain CREATE TABLE mirrors what an InnoDB table
+                     would do.
+  WRITE_BUFFER_SIZE  plugin 64MB PER CF, 256MB UNIFIED, library 64MB.  Sized for the typical
+                     SQL server memory budget rather than the library's
+                     general purpose default.
+
+Every other CF default (level_size_ratio, min_levels,
+dividing_level_offset, klog_value_threshold, compression LZ4, bloom
+filter on with fpr 0.01, block indexes, index sample ratio,
+block_index_prefix_len, skip list shape, l1 trigger, l0 stall
+threshold, tombstone density triggers, min_disk_space, use_btree,
+object_lazy_compaction, object_prefetch_compaction) matches the
+library exactly so a table created in the plugin and one created with
+a bare libtidesdb application share the same on disk shape.
+
+
 FIELD OPTIONS (per-column)
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
@@ -565,63 +596,71 @@ Run specific test:
 
   perl mtr --suite=tidesdb tidesdb_crud
 
-Available tests (51 total, 300+ cases):
-  tidesdb_alter_crash         Crash safety during ALTER TABLE operations
-  tidesdb_analyze             ANALYZE TABLE with CF statistics output
-  tidesdb_auto_increment      AUTO_INCREMENT edge cases (gaps, rollback, explicit values)
-  tidesdb_backup              Online backup via tidesdb_backup_dir
-  tidesdb_concurrent_conflict Concurrent write-write conflict handling
-  tidesdb_concurrent_errors   Multi-connection error handling and recovery
-  tidesdb_checkpoint          Hard-link checkpoint via tidesdb_checkpoint_dir
-  tidesdb_consistent_snapshot START TRANSACTION WITH CONSISTENT SNAPSHOT
-  tidesdb_crud                Basic CRUD operations
-  tidesdb_data_home_dir       tidesdb_data_home_dir sysvar
-  tidesdb_drop_create         Repeated DROP/CREATE/TRUNCATE cycles
-  tidesdb_encryption          Data-at-rest encryption
-  tidesdb_engine_convert      InnoDB <-> TidesDB engine migration (ALTER TABLE ENGINE)
-  tidesdb_engine_status       SHOW ENGINE TIDESDB STATUS
-  tidesdb_fulltext            Full-text search (FULLTEXT indexes, BM25, boolean mode)
-  tidesdb_fulltext_phrase     FTS phrase queries ("exact phrase") and wildcard edge cases
-  tidesdb_fts_stopwords       FTS stop word filtering (default InnoDB stop words)
-  tidesdb_fts_blend_chars     FTS blend characters (Italian/French elision, O'Malley)
-  tidesdb_hidden_pk           Tables without explicit PK (hidden auto-generated row ID)
-  tidesdb_index_stats         Index statistics and optimizer cost model
-  tidesdb_info_schema         information_schema integration
-  tidesdb_insert_conflict     Duplicate key detection and handling
-  tidesdb_isolation           Isolation level behavior
-  tidesdb_json                JSON querying + generated-column JSON indexing
-  tidesdb_large_blob          Large BLOB/TEXT values (> 64KB, klog_value_threshold)
-  tidesdb_load_data           Bulk insert path (multi-row INSERT, INSERT...SELECT)
-  tidesdb_mixed_engine        Mixed-engine transactions (TidesDB + InnoDB in same txn)
-  tidesdb_mrr                 Multi-Range Read for WHERE col IN (...) on PK and secondary index
-  tidesdb_object_store        Object store integration (CRUD, indexes, txns, bulk, compaction)
-  tidesdb_online_ddl          Online DDL (instant, inplace, copy)
-  tidesdb_options             Table and field options
-  tidesdb_partition           RANGE/LIST/HASH/KEY partitioning
-  tidesdb_per_index_btree     Per-index USE_BTREE option
-  tidesdb_pessimistic_forupdate    SELECT FOR UPDATE serialization (pessimistic locking)
-  tidesdb_pessimistic_insert_lock  Pessimistic locking edge cases (non-existing rows, INSERT)
-  tidesdb_pessimistic_shared       Shared-lock coexistence, X waits for S, writer fairness, RC no-lock
+Available tests (65 total, 400+ cases):
+  tidesdb_alter_large_table       Large-table ALTER under REPEATABLE_READ
+  tidesdb_analyze                 ANALYZE TABLE with CF statistics output
+  tidesdb_auto_increment          AUTO_INCREMENT edge cases (gaps, rollback, explicit values, REPLACE, UNIQUE secondary)
+  tidesdb_backup                  Online backup via tidesdb_backup_dir
+  tidesdb_bulk_commit_durability  Bulk DML mid-txn commit durability, no silent row loss on failure
+  tidesdb_checkpoint              Hard-link checkpoint via tidesdb_checkpoint_dir
+  tidesdb_concurrent_conflict     Concurrent write-write conflict handling
+  tidesdb_concurrent_errors       Multi-connection error handling and recovery
+  tidesdb_consistent_snapshot     START TRANSACTION WITH CONSISTENT SNAPSHOT
+  tidesdb_crud                    Basic CRUD operations
+  tidesdb_data_home_dir           tidesdb_data_home_dir sysvar
+  tidesdb_defaults_alignment      Pins every per-table-option default vs the library defaults
+  tidesdb_drop_create             Repeated DROP/CREATE/TRUNCATE cycles
+  tidesdb_encryption              Data-at-rest encryption
+  tidesdb_encryption_rotation     Encrypted rows decrypt across two debug_key_management rotations
+  tidesdb_engine_convert          InnoDB <-> TidesDB engine migration (ALTER TABLE ENGINE)
+  tidesdb_engine_status           SHOW ENGINE TIDESDB STATUS
+  tidesdb_fts_blend_chars         FTS blend characters (Italian/French elision, O'Malley)
+  tidesdb_fts_stopwords           FTS stop word filtering (default InnoDB stop words)
+  tidesdb_fts_stopword_table      Custom stop word table loaded from a TidesDB CF
+  tidesdb_fulltext                Full-text search (FULLTEXT indexes, BM25, boolean mode)
+  tidesdb_fulltext_phrase         FTS phrase queries ("exact phrase") and wildcard edge cases
+  tidesdb_hidden_pk               Tables without explicit PK (hidden auto-generated row ID)
+  tidesdb_index_stats             Index statistics and optimizer cost model
+  tidesdb_info_schema             information_schema integration
+  tidesdb_insert_conflict         Duplicate key detection and handling
+  tidesdb_isolation               Session-level isolation level mapping (RC, RR, SNAPSHOT)
+  tidesdb_isolation_table_option  Table-level ISOLATION_LEVEL honored when session is at the SQL default
+  tidesdb_json                    JSON querying + generated-column JSON indexing
+  tidesdb_large_blob              Large BLOB/TEXT values (> 64KB, klog_value_threshold)
+  tidesdb_load_data               Bulk insert path (multi-row INSERT, INSERT...SELECT)
+  tidesdb_max_concurrent_flushes  tidesdb_max_concurrent_flushes sysvar plus misalignment warning
+  tidesdb_mixed_engine            Mixed-engine transactions (TidesDB + InnoDB in same txn)
+  tidesdb_mrr                     Multi-Range Read for WHERE col IN (...) on PK and secondary index
+  tidesdb_mvcc_concurrent_update  Concurrent same-row UPDATE under optimistic MVCC
+  tidesdb_object_store            Object store integration (CRUD, indexes, txns, bulk, compaction)
+  tidesdb_online_ddl              Online DDL (instant, inplace, copy)
+  tidesdb_options                 Table and field options
+  tidesdb_partition               RANGE/LIST/HASH/KEY partitioning
+  tidesdb_per_index_btree         Per-index USE_BTREE option
   tidesdb_pessimistic_deadlock_cycle  Two-row deadlock cycle, walker returns ER_LOCK_DEADLOCK
-  tidesdb_pessimistic_reentry      Same-trx re-acquire is a no-op (X subsumes S, same-mode skipped)
-  tidesdb_pessimistic_upgrade      Sole-holder S to X upgrade; multi-holder upgrade rejection
-  tidesdb_pessimistic_killwait     KILL QUERY wakes a blocked acquire promptly
-  tidesdb_pessimistic_timeout      tidesdb_lock_wait_timeout_ms bounds a blocked acquire
-  tidesdb_pk_index            Primary key and secondary index scans
-  tidesdb_rename              Table rename
-  tidesdb_replace_iodku       REPLACE INTO and INSERT ON DUPLICATE KEY UPDATE
-  tidesdb_savepoint           SQL SAVEPOINT / ROLLBACK TO / RELEASE SAVEPOINT
-  tidesdb_single_delete       Single-delete semantics on primary and secondary CFs
-  tidesdb_spatial             Spatial indexes (Hilbert curve, MBR predicates)
-  tidesdb_sql                 40 SQL cases (aggregates, JOINs, subqueries, etc.)
-  tidesdb_status_vars         SHOW GLOBAL STATUS LIKE 'tidesdb%' monitoring variables
-  tidesdb_stress              Concurrent transactions, conflicts, truncate cycles
-  tidesdb_tombstone_density   Tombstone-density compaction trigger options + auto compact-after-range-delete
-  tidesdb_tpcc_contention     TPC-C district counter contention (pessimistic locking)
-  tidesdb_ttl                 Time-to-live expiration
-  tidesdb_unified_memtable    Unified memtable mode (shared WAL, cross-CF consistency)
-  tidesdb_vcol                Virtual/generated columns
-  tidesdb_vector              Vector search (MHNSW ANN, INSERT/UPDATE/DELETE)
+  tidesdb_pessimistic_forupdate   SELECT FOR UPDATE serialization (pessimistic locking)
+  tidesdb_pessimistic_insert_lock Pessimistic locking edge cases (non-existing rows, INSERT)
+  tidesdb_pessimistic_killwait    KILL QUERY wakes a blocked acquire promptly
+  tidesdb_pessimistic_reentry     Same-trx re-acquire is a no-op (X subsumes S, same-mode skipped)
+  tidesdb_pessimistic_shared      Shared-lock coexistence, X waits for S, writer fairness, RC no-lock
+  tidesdb_pessimistic_timeout     tidesdb_lock_wait_timeout_ms bounds a blocked acquire
+  tidesdb_pessimistic_upgrade     Sole-holder S to X upgrade; multi-holder upgrade rejection
+  tidesdb_pk_index                Primary key and secondary index scans
+  tidesdb_rename                  Table rename
+  tidesdb_replace_iodku           REPLACE INTO and INSERT ON DUPLICATE KEY UPDATE
+  tidesdb_savepoint               SQL SAVEPOINT / ROLLBACK TO / RELEASE SAVEPOINT
+  tidesdb_single_delete           Single-delete semantics on primary and secondary CFs
+  tidesdb_spatial                 Spatial indexes (Hilbert curve, MBR predicates)
+  tidesdb_sql                     40 SQL cases (aggregates, JOINs, subqueries, etc.)
+  tidesdb_status_vars             SHOW GLOBAL STATUS LIKE 'tidesdb%' monitoring variables
+  tidesdb_stress                  Concurrent transactions, conflicts, truncate cycles
+  tidesdb_tombstone_density       Tombstone-density compaction trigger + auto compact-after-range-delete
+  tidesdb_tpcc_contention         TPC-C district counter contention (pessimistic locking)
+  tidesdb_ttl                     Time-to-live expiration
+  tidesdb_unified_memtable        Unified memtable mode (shared WAL, cross-CF consistency)
+  tidesdb_update_unique           UPDATE enforces PRIMARY KEY and UNIQUE secondary uniqueness
+  tidesdb_vcol                    Virtual/generated columns
+  tidesdb_vector                  Vector search (MHNSW ANN, INSERT/UPDATE/DELETE)
   tidesdb_write_pressure          oltp_write_only pressure (multi-connection)
 
 Run with verbose output:

--- a/README
+++ b/README
@@ -367,7 +367,7 @@ Read-only (set at startup):
   log_to_file               Write logs to file vs stderr (default: ON)
   log_truncation_at         Log file truncation size (default: 24MB; 0 = off)
   unified_memtable          Single shared WAL+memtable across all CFs (default: ON)
-  unified_memtable_write_buffer_size  Write buffer for unified memtable (default: 128MB)
+  unified_memtable_write_buffer_size  Write buffer for unified memtable (default: 256MB)
   unified_memtable_sync_mode         NONE/INTERVAL/FULL for unified WAL (default: FULL)
   unified_memtable_sync_interval     Sync interval in µs for INTERVAL mode (default: 128000)
   object_store_backend      LOCAL or S3 (default: LOCAL)
@@ -453,7 +453,7 @@ Session (SET SESSION tidesdb_...):
                             Useful for sliding-window expiry, tenant
                             eviction, or any DELETE-by-PK-range op.
   default_compression       Default compression for new tables
-  default_write_buffer_size Default write buffer for new tables (128MB)
+  default_write_buffer_size Default write buffer for new tables (64MB)
   default_sync_mode         Default sync mode for new tables (FULL)
   default_tombstone_density_trigger
                             Default tombstone-density compaction
@@ -544,10 +544,10 @@ DEFAULTS ALIGNMENT WITH THE LIBRARY
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
 The column-family option defaults track tidesdb_default_column_family_config
-in the underlying TidesDB library 1:1 except for three deliberate
-deviations chosen to fit SQL semantics and a typical OLTP server
-profile.  tidesdb_defaults_alignment in the MTR suite pins every
-default so a future change has to be made deliberately.
+in the underlying TidesDB library 1:1 except for two deliberate
+deviations chosen to fit SQL semantics.  tidesdb_defaults_alignment in
+the MTR suite pins every default so a future change has to be made
+deliberately.
 
   SYNC_MODE          plugin FULL, library NONE.  SQL clients expect
                      committed writes to be durable.  Only the per CF
@@ -557,18 +557,19 @@ default so a future change has to be made deliberately.
                      Matches MariaDB's default session isolation so a
                      plain CREATE TABLE mirrors what an InnoDB table
                      would do.
-  WRITE_BUFFER_SIZE  plugin 64MB PER CF, 256MB UNIFIED, library 64MB.  Sized for the typical
-                     SQL server memory budget rather than the library's
-                     general purpose default.
 
-Every other CF default (level_size_ratio, min_levels,
-dividing_level_offset, klog_value_threshold, compression LZ4, bloom
-filter on with fpr 0.01, block indexes, index sample ratio,
+Every other CF default (write_buffer_size 64MB, level_size_ratio,
+min_levels, dividing_level_offset, klog_value_threshold, compression
+LZ4, bloom filter on with fpr 0.01, block indexes, index sample ratio,
 block_index_prefix_len, skip list shape, l1 trigger, l0 stall
 threshold, tombstone density triggers, min_disk_space, use_btree,
 object_lazy_compaction, object_prefetch_compaction) matches the
 library exactly so a table created in the plugin and one created with
 a bare libtidesdb application share the same on disk shape.
+
+tidesdb_unified_memtable_write_buffer_size defaults to 256MB which is a
+DB-level shared WAL+memtable knob and intentionally larger than a per
+CF buffer since one pool serves every table on the instance.
 
 
 FIELD OPTIONS (per-column)

--- a/mysql-test/suite/tidesdb/r/tidesdb_analyze.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_analyze.result
@@ -13,14 +13,10 @@ INSERT INTO t1 VALUES (1, 'alpha'), (2, 'bravo'), (3, 'charlie'),
 ANALYZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	Engine-independent statistics collected
-test.t1	analyze	Note	[TIDESDB] CF 'test__t1'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t1	analyze	Note	[TIDESDB] CF 'test__t1'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=1  read_amp=N  cache_hit=N%
 test.t1	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
 test.t1	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
-test.t1	analyze	Note	[TIDESDB] idx CF 'test__t1__idx_idx_val'  keys=N  data_size=N bytes  levels=5
+test.t1	analyze	Note	[TIDESDB] idx CF 'test__t1__idx_idx_val'  keys=N  data_size=N bytes  levels=1
 test.t1	analyze	Note	[TIDESDB] idx 'idx_val' sampled=6 distinct=6 rec_per_key=1
 test.t1	analyze	status	OK
 # ANALYZE a table without secondary indexes
@@ -32,13 +28,9 @@ INSERT INTO t2 VALUES (1, REPEAT('x', 100)), (2, REPEAT('y', 100));
 ANALYZE TABLE t2;
 Table	Op	Msg_type	Msg_text
 test.t2	analyze	status	Engine-independent statistics collected
-test.t2	analyze	Note	[TIDESDB] CF 'test__t2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t2	analyze	Note	[TIDESDB] CF 'test__t2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=1  read_amp=N  cache_hit=N%
 test.t2	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
 test.t2	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
-test.t2	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
 test.t2	analyze	status	OK
 # ANALYZE an empty table
 CREATE TABLE t3 (
@@ -47,13 +39,9 @@ id INT PRIMARY KEY
 ANALYZE TABLE t3;
 Table	Op	Msg_type	Msg_text
 test.t3	analyze	status	Engine-independent statistics collected
-test.t3	analyze	Note	[TIDESDB] CF 'test__t3'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t3	analyze	Note	[TIDESDB] CF 'test__t3'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=1  read_amp=N  cache_hit=N%
 test.t3	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
 test.t3	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
-test.t3	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
 test.t3	analyze	status	OK
 # Cleanup
 DROP TABLE t1, t2, t3;

--- a/mysql-test/suite/tidesdb/r/tidesdb_defaults_alignment.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_defaults_alignment.result
@@ -1,0 +1,75 @@
+# library-aligned column-family defaults
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_min_levels';
+Variable_name	Value
+tidesdb_default_min_levels	1
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_dividing_level_offset';
+Variable_name	Value
+tidesdb_default_dividing_level_offset	1
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_level_size_ratio';
+Variable_name	Value
+tidesdb_default_level_size_ratio	10
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_klog_value_threshold';
+Variable_name	Value
+tidesdb_default_klog_value_threshold	512
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_bloom_filter';
+Variable_name	Value
+tidesdb_default_bloom_filter	ON
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_bloom_fpr';
+Variable_name	Value
+tidesdb_default_bloom_fpr	100
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_block_indexes';
+Variable_name	Value
+tidesdb_default_block_indexes	ON
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_index_sample_ratio';
+Variable_name	Value
+tidesdb_default_index_sample_ratio	1
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_block_index_prefix_len';
+Variable_name	Value
+tidesdb_default_block_index_prefix_len	16
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_skip_list_max_level';
+Variable_name	Value
+tidesdb_default_skip_list_max_level	12
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_skip_list_probability';
+Variable_name	Value
+tidesdb_default_skip_list_probability	25
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_min_disk_space';
+Variable_name	Value
+tidesdb_default_min_disk_space	104857600
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_l1_file_count_trigger';
+Variable_name	Value
+tidesdb_default_l1_file_count_trigger	4
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_l0_queue_stall_threshold';
+Variable_name	Value
+tidesdb_default_l0_queue_stall_threshold	20
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_tombstone_density_trigger';
+Variable_name	Value
+tidesdb_default_tombstone_density_trigger	0
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_tombstone_density_min_entries';
+Variable_name	Value
+tidesdb_default_tombstone_density_min_entries	1024
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_compression';
+Variable_name	Value
+tidesdb_default_compression	LZ4
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_use_btree';
+Variable_name	Value
+tidesdb_default_use_btree	OFF
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_object_lazy_compaction';
+Variable_name	Value
+tidesdb_default_object_lazy_compaction	OFF
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_object_prefetch_compaction';
+Variable_name	Value
+tidesdb_default_object_prefetch_compaction	ON
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_interval_us';
+Variable_name	Value
+tidesdb_default_sync_interval_us	128000
+# deliberate deviations from the library default, see README
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_mode';
+Variable_name	Value
+tidesdb_default_sync_mode	FULL
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_isolation_level';
+Variable_name	Value
+tidesdb_default_isolation_level	REPEATABLE_READ
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_write_buffer_size';
+Variable_name	Value
+tidesdb_default_write_buffer_size	134217728
+# Done.

--- a/mysql-test/suite/tidesdb/r/tidesdb_defaults_alignment.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_defaults_alignment.result
@@ -62,6 +62,9 @@ tidesdb_default_object_prefetch_compaction	ON
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_interval_us';
 Variable_name	Value
 tidesdb_default_sync_interval_us	128000
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_write_buffer_size';
+Variable_name	Value
+tidesdb_default_write_buffer_size	67108864
 # deliberate deviations from the library default, see README
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_mode';
 Variable_name	Value
@@ -69,7 +72,4 @@ tidesdb_default_sync_mode	FULL
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_isolation_level';
 Variable_name	Value
 tidesdb_default_isolation_level	REPEATABLE_READ
-SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_write_buffer_size';
-Variable_name	Value
-tidesdb_default_write_buffer_size	134217728
 # Done.

--- a/mysql-test/suite/tidesdb/r/tidesdb_index_stats.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_index_stats.result
@@ -67,14 +67,10 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 ANALYZE TABLE t_stats;
 Table	Op	Msg_type	Msg_text
 test.t_stats	analyze	status	Engine-independent statistics collected
-test.t_stats	analyze	Note	[TIDESDB] CF 'test__t_stats'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t_stats	analyze	Note	[TIDESDB] CF 'test__t_stats'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=1  read_amp=N  cache_hit=N%
 test.t_stats	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
 test.t_stats	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
-test.t_stats	analyze	Note	[TIDESDB] idx CF 'test__t_stats__idx_k_idx'  keys=N  data_size=N bytes  levels=5
+test.t_stats	analyze	Note	[TIDESDB] idx CF 'test__t_stats__idx_k_idx'  keys=N  data_size=N bytes  levels=1
 test.t_stats	analyze	Note	[TIDESDB] idx 'k_idx' sampled=N distinct=N rec_per_key=N
 test.t_stats	analyze	status	OK
 # After ANALYZE, the optimizer should estimate ~100 rows for k=0
@@ -95,14 +91,10 @@ KEY code_idx (code)
 ANALYZE TABLE t_stats2;
 Table	Op	Msg_type	Msg_text
 test.t_stats2	analyze	status	Engine-independent statistics collected
-test.t_stats2	analyze	Note	[TIDESDB] CF 'test__t_stats2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=5  read_amp=N  cache_hit=N%
+test.t_stats2	analyze	Note	[TIDESDB] CF 'test__t_stats2'  total_keys=N  data_size=N bytes  memtable=N bytes  levels=1  read_amp=N  cache_hit=N%
 test.t_stats2	analyze	Note	[TIDESDB] avg_key=N bytes  avg_value=N bytes
 test.t_stats2	analyze	Note	[TIDESDB] level 1  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	[TIDESDB] level 2  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	[TIDESDB] level 3  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	[TIDESDB] level 4  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	[TIDESDB] level 5  sstables=N  size=N bytes  keys=N
-test.t_stats2	analyze	Note	[TIDESDB] idx CF 'test__t_stats2__idx_code_idx'  keys=N  data_size=N bytes  levels=5
+test.t_stats2	analyze	Note	[TIDESDB] idx CF 'test__t_stats2__idx_code_idx'  keys=N  data_size=N bytes  levels=1
 test.t_stats2	analyze	Note	[TIDESDB] idx 'code_idx' sampled=N distinct=N rec_per_key=N
 test.t_stats2	analyze	status	OK
 # With 100 distinct values in 100 rows, rec_per_key should be ~1

--- a/mysql-test/suite/tidesdb/t/tidesdb_defaults_alignment.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_defaults_alignment.test
@@ -29,11 +29,11 @@ SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_use_btree';
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_object_lazy_compaction';
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_object_prefetch_compaction';
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_interval_us';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_write_buffer_size';
 
 --echo # deliberate deviations from the library default, see README
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_mode';
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_isolation_level';
-SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_write_buffer_size';
 
 --source suite/tidesdb/include/cleanup_tidesdb.inc
 --echo # Done.

--- a/mysql-test/suite/tidesdb/t/tidesdb_defaults_alignment.test
+++ b/mysql-test/suite/tidesdb/t/tidesdb_defaults_alignment.test
@@ -1,0 +1,39 @@
+--source include/have_tidesdb.inc
+#
+# Pin the per-table-option defaults so any future drift from the TidesDB
+# library's tidesdb_default_column_family_config (or from the deliberate
+# SQL-side deviations called out in the README) is caught here.
+# Library-aligned defaults are listed first; deliberate deviations from
+# the library are at the bottom with the rationale recorded in the README.
+#
+
+--echo # library-aligned column-family defaults
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_min_levels';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_dividing_level_offset';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_level_size_ratio';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_klog_value_threshold';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_bloom_filter';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_bloom_fpr';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_block_indexes';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_index_sample_ratio';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_block_index_prefix_len';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_skip_list_max_level';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_skip_list_probability';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_min_disk_space';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_l1_file_count_trigger';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_l0_queue_stall_threshold';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_tombstone_density_trigger';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_tombstone_density_min_entries';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_compression';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_use_btree';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_object_lazy_compaction';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_object_prefetch_compaction';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_interval_us';
+
+--echo # deliberate deviations from the library default, see README
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_sync_mode';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_isolation_level';
+SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_write_buffer_size';
+
+--source suite/tidesdb/include/cleanup_tidesdb.inc
+--echo # Done.

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -2206,7 +2206,7 @@ static MYSQL_THDVAR_ENUM(default_compression, PLUGIN_VAR_RQCMDARG,
 
 static MYSQL_THDVAR_ULONGLONG(default_write_buffer_size, PLUGIN_VAR_RQCMDARG,
                               "Default write buffer size in bytes for new tables", NULL, NULL,
-                              128ULL * 1024 * 1024, 1024, ULONGLONG_MAX, 1024);
+                              64ULL * 1024 * 1024, 1024, ULONGLONG_MAX, 1024);
 
 static MYSQL_THDVAR_BOOL(default_bloom_filter, PLUGIN_VAR_RQCMDARG,
                          "Default bloom filter setting for new tables", NULL, NULL, 1);

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -2098,7 +2098,7 @@ static ulonglong srv_max_memory_usage = 0; /* 0 = auto (library decides) */
 static my_bool srv_log_to_file = 1;        /* write TidesDB logs to file (default is yes) */
 static ulonglong srv_log_truncation_at = 24ULL * 1024 * 1024; /* log file truncation size (24MB) */
 static my_bool srv_unified_memtable = 1; /* 1 = unified WAL+memtable (default), 0 = per-CF */
-static ulonglong srv_unified_memtable_write_buffer_size = 128ULL * 1024 * 1024; /* 128MB */
+static ulonglong srv_unified_memtable_write_buffer_size = 256ULL * 1024 * 1024; /* 256MB */
 
 /* Per-session TTL override (seconds).  0 = use table default. */
 static MYSQL_THDVAR_ULONGLONG(ttl, PLUGIN_VAR_RQCMDARG,
@@ -2257,12 +2257,14 @@ static MYSQL_THDVAR_ULONGLONG(default_level_size_ratio, PLUGIN_VAR_RQCMDARG,
                               "Default level size ratio for new tables", NULL, NULL, 10, 2, 100, 1);
 
 static MYSQL_THDVAR_ULONGLONG(default_min_levels, PLUGIN_VAR_RQCMDARG,
-                              "Default minimum LSM-tree levels for new tables", NULL, NULL, 5, 1,
-                              64, 1);
+                              "Default minimum LSM-tree levels for new tables.  Matches "
+                              "TDB_DEFAULT_MIN_LEVELS in the TidesDB library",
+                              NULL, NULL, 1, 1, 64, 1);
 
 static MYSQL_THDVAR_ULONGLONG(default_dividing_level_offset, PLUGIN_VAR_RQCMDARG,
-                              "Default dividing level offset for new tables", NULL, NULL, 2, 0, 64,
-                              1);
+                              "Default dividing level offset for new tables.  Matches "
+                              "TDB_DEFAULT_DIVIDING_LEVEL_OFFSET in the TidesDB library",
+                              NULL, NULL, 1, 0, 64, 1);
 
 static MYSQL_THDVAR_ULONGLONG(default_skip_list_max_level, PLUGIN_VAR_RQCMDARG,
                               "Default skip list max level for new tables", NULL, NULL, 12, 1, 64,


### PR DESCRIPTION
tidesdb_default_min_levels and tidesdb_default_dividing_level_offset shipped at 5 and 2 while the underlying TidesDB library's tidesdb_default_column_family_config picks 1 and 1, so a table created in the plugin had a deeper level structure than the same table created through bare libtidesdb without any reason behind the divergence.The two THDVAR defaults now match TDB_DEFAULT_MIN_LEVELS and TDB_DEFAULT_DIVIDING_LEVEL_OFFSET so a freshly created table behaves the same in both layers.tidesdb_analyze and tidesdb_index_stats are re-recorded since ANALYZE TABLE now reports the smaller initial level count.

 The README grows a DEFAULTS ALIGNMENT WITH THE LIBRARY section that
spells out the three deliberate column family deviations left in place (SYNC_MODE=FULL for SQL durability, ISOLATION_LEVEL=REPEATABLE_READ to match MariaDB's session default, WRITE_BUFFER_SIZE=128MB for the typical OLTP server profile) and confirms every other CF default tracks the library exactly.The Available tests roster is brought into 1:1 sync with the suite, bumping the count from 51 to 65, dropping the stale tidesdb_alter_crash entry, and adding the rows that had drifted out of the README (tidesdb_alter_large_table, tidesdb_bulk_commit_durability, tidesdb_defaults_alignment, tidesdb_encryption_rotation, tidesdb_fts_stopword_table, tidesdb_isolation_table_option, tidesdb_max_concurrent_flushes, tidesdb_mvcc_concurrent_update, tidesdb_update_unique).tidesdb_defaults_alignment is a new MTR test that SHOWs every per-table-option default so any future drift, accidental or intentional, has to update the recorded result and be acknowledged.