### PR TITLE
absorb new TDB_ERR_BUSY library code and pin L0 stall

### DIFF
--- a/README
+++ b/README
@@ -509,7 +509,7 @@ LSM Tree:
   MIN_LEVELS                Minimum LSM levels (default: 1, matches library)
   DIVIDING_LEVEL_OFFSET     Compaction dividing level offset (default: 1, matches library)
   L1_FILE_COUNT_TRIGGER     L1 file count trigger for compaction (default: 4)
-  L0_QUEUE_STALL_THRESHOLD  L0 queue stall threshold (default: 20)
+  L0_QUEUE_STALL_THRESHOLD  L0 queue stall threshold (default: 10, matches library)
   TOMBSTONE_DENSITY_TRIGGER Ratio in parts per 10000 above which compaction
                             is escalated for a single SSTable when the
                             tombstone-density check fires after a flush

--- a/mysql-test/suite/tidesdb/r/tidesdb_defaults_alignment.result
+++ b/mysql-test/suite/tidesdb/r/tidesdb_defaults_alignment.result
@@ -40,7 +40,7 @@ Variable_name	Value
 tidesdb_default_l1_file_count_trigger	4
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_l0_queue_stall_threshold';
 Variable_name	Value
-tidesdb_default_l0_queue_stall_threshold	20
+tidesdb_default_l0_queue_stall_threshold	10
 SHOW GLOBAL VARIABLES LIKE 'tidesdb_default_tombstone_density_trigger';
 Variable_name	Value
 tidesdb_default_tombstone_density_trigger	0

--- a/tidesdb/ha_tidesdb.cc
+++ b/tidesdb/ha_tidesdb.cc
@@ -108,8 +108,16 @@ static int tdb_rc_to_ha(int rc, const char *ctx)
            waiting for capacity, so this fall-through path only fires
            when the configured wait timeout has been exhausted or no
            wrapper is in play -- in either case lock-wait-timeout is the
-           accurate name (not deadlock; nothing is locked). */
+           accurate name (not deadlock; nothing is locked).
+
+           TDB_ERR_BUSY is the same family.  The library now distinguishes
+           a soft cap (TDB_ERR_MEMORY_LIMIT) from the case where it has
+           stalled long enough that its internal no-progress budget was
+           spent without freeing capacity.  Both are transient and the
+           plugin treats them the same once the in-plugin backoff has
+           given up. */
         case TDB_ERR_MEMORY_LIMIT:
+        case TDB_ERR_BUSY:
             return HA_ERR_LOCK_WAIT_TIMEOUT;
 
         /* Hard out-of-memory.  Distinct from TDB_ERR_MEMORY_LIMIT above
@@ -234,7 +242,7 @@ template <typename Op>
 static int tdb_with_backpressure_wait(THD *thd, Op &&op)
 {
     int rc = op();
-    if (likely(rc != TDB_ERR_MEMORY_LIMIT)) return rc;
+    if (likely(rc != TDB_ERR_MEMORY_LIMIT && rc != TDB_ERR_BUSY)) return rc;
 
     const ulong timeout_ms = tdb_backpressure_timeout_ms(thd);
     if (timeout_ms == 0) return rc;
@@ -244,7 +252,7 @@ static int tdb_with_backpressure_wait(THD *thd, Op &&op)
     bool counted = false;
     long long waited_us = 0;
 
-    while (rc == TDB_ERR_MEMORY_LIMIT)
+    while (rc == TDB_ERR_MEMORY_LIMIT || rc == TDB_ERR_BUSY)
     {
         if (thd && thd_killed(thd)) break;
 
@@ -2246,7 +2254,7 @@ static MYSQL_THDVAR_ULONGLONG(default_klog_value_threshold, PLUGIN_VAR_RQCMDARG,
                               NULL, NULL, 512, 0, ULONGLONG_MAX, 1);
 
 static MYSQL_THDVAR_ULONGLONG(default_l0_queue_stall_threshold, PLUGIN_VAR_RQCMDARG,
-                              "Default L0 queue stall threshold for new tables", NULL, NULL, 20, 1,
+                              "Default L0 queue stall threshold for new tables", NULL, NULL, 10, 1,
                               1024, 1);
 
 static MYSQL_THDVAR_ULONGLONG(default_l1_file_count_trigger, PLUGIN_VAR_RQCMDARG,
@@ -3308,7 +3316,8 @@ static int tidesdb_commit(handlerton *, THD *thd, bool all)
         if (rc != TDB_SUCCESS)
         {
             /* Only log truly unexpected errors (not transient conflicts). */
-            if (rc != TDB_ERR_CONFLICT && rc != TDB_ERR_LOCKED && rc != TDB_ERR_MEMORY_LIMIT)
+            if (rc != TDB_ERR_CONFLICT && rc != TDB_ERR_LOCKED && rc != TDB_ERR_MEMORY_LIMIT &&
+                rc != TDB_ERR_BUSY)
                 sql_print_error(
                     "[TIDESDB] hton_commit: tidesdb_txn_commit returned %d "
                     "(dirty=%d gen=%lu)",
@@ -10371,8 +10380,8 @@ static long long srv_stat_cache_partitions;
    tidesdb_show_status can read them directly.  Their definitions live up
    there. */
 
-#define TIDESQL_VERSION_STR "4.5.2"
-#define TIDESQL_VERSION_HEX 0x40502
+#define TIDESQL_VERSION_STR "4.5.3"
+#define TIDESQL_VERSION_HEX 0x40503
 
 static const char *srv_stat_version = TIDESQL_VERSION_STR;
 static long long srv_stat_version_hex = TIDESQL_VERSION_HEX;


### PR DESCRIPTION
default to the library

The latest libtidesdb release adds TDB_ERR_BUSY at -14,
 defined as the
case where the engine gave up after its internal
backpressure stall
budget ran out without freeing memtable or L0 capacity.
 It is transient
in exactly the same way as TDB_ERR_MEMORY_LIMIT, so the
 plugin now
folds it into the same three paths. The rc map sends it
 to
HA_ERR_LOCK_WAIT_TIMEOUT alongside the existing memory limit branch,
tdb_with_backpressure_wait keeps retrying inside the configured
backpressure timeout instead of bubbling the error up immediately, and
the hton_commit unexpected error log filter excludes it
 so a busy
commit no longer spams the error log. Without this change every write
heavy workload would surface ER_GET_ERRNO 1030 on the first stall
budget exhaustion even though the engine was healthy and just needed a
moment to drain.

tidesdb_default_l0_queue_stall_threshold shipped at 20 while the
underlying TDB_DEFAULT_L0_QUEUE_STALL_THRESHOLD is 10, so a freshly
created table queued twice as many immutable memtables before
backpressure kicked in compared with the same table created through
bare libtidesdb. The THDVAR default now matches the library 